### PR TITLE
passing tests and added new parameter to model

### DIFF
--- a/multidms/model.py
+++ b/multidms/model.py
@@ -217,6 +217,13 @@ class Model:
             )
 
         elif epistatic_model == multidms.biophysical.softplus_global_epistasis:
+            if output_activation != multidms.biophysical.softplus_activation:
+                warnings.warn(
+                    "softplus_global_epistasis has no natural lower bound,"
+                    " we highly suggest using a softplus output activation"
+                    "with a lower bound specified when using this model."
+                )
+
             self._params["theta"] = dict(
                 ge_scale=jnp.array([init_theta_scale]),
                 ge_bias=jnp.array([init_theta_bias]),

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -89,6 +89,10 @@ class Model:
         If using `biophysical.multidms.biophysical.nn_global_epistasis`
         as the epistatic model, this is the number of hidden units
         used in the transform.
+    lower_bound : float or None
+        If using `biophysical.multidms.biophysical.softplus_activation`
+        as the output activation, this is the lower bound of the
+        softplus function.
 
     Example
     -------
@@ -179,6 +183,7 @@ class Model:
         init_theta_scale=5.0,
         init_theta_bias=-5.0,
         n_hidden_units=5,
+        lower_bound=None,
     ):
         """See class docstring."""
         self.gamma_corrected = gamma_corrected
@@ -235,6 +240,18 @@ class Model:
 
         else:
             raise ValueError(f"{epistatic_model} not recognized,")
+
+        if output_activation == multidms.biophysical.softplus_activation:
+            if lower_bound is None:
+                raise ValueError(
+                    "softplus activation requires a lower bound be specified"
+                )
+            elif type(lower_bound) != float:
+                raise ValueError("lower_bound must be a float")
+            else:
+                output_activation = partial(
+                    multidms.biophysical.softplus_activation, lower_bound=lower_bound
+                )
 
         for condition in data.conditions:
             self._params[f"gamma_{condition}"] = jnp.zeros(shape=(1,))


### PR DESCRIPTION
This PR addresses #75 by adding a `lower_bound` parameter to the Model class, and using that to update the output activation component as a partial function with the lower bound set. We add some tests to make sure this behaves as expected.