### PR TITLE
properly implement `letter_suffixed_sites` in `Data`

### DIFF
--- a/multidms/__init__.py
+++ b/multidms/__init__.py
@@ -53,7 +53,7 @@ It also imports the following alphabets:
 
 __author__ = "Jared Galloway"
 __email__ = "jgallowa@fredhutch.org"
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __url__ = "https://github.com/matsengrp/multidms"
 
 from polyclonal.alphabets import AAS  # noqa: F401

--- a/multidms/data.py
+++ b/multidms/data.py
@@ -362,6 +362,7 @@ class Data:
                 substitutions_col="var_wrt_ref",
                 allowed_subs=allowed_subs,
                 alphabet=self.alphabet,
+                sites_as_str=letter_suffixed_sites,
             )
             binmaps[condition] = ref_bmap
             X[condition] = sparse.BCOO.from_scipy_sparse(ref_bmap.binary_variants)


### PR DESCRIPTION
Previously the `letter_suffixed_sites` parameter to `Data` did not work properly as it wasn't passed to `BinaryMap`. This is now fixed.

Also incremented version to 0.1.5.

Note that this was ultimate source of error described here: https://github.com/dms-vep/dms-vep-pipeline-3/issues/1