### PR TITLE
patch links for biophysical and example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,9 +20,9 @@ and how much the effects differ between experiments.
 
 - The preprint is available on `bioRxiv <https://www.biorxiv.org/content/10.1101/2023.07.31.551037v1>`_.
 
-- A concise description of the joint modeling approach is available in the `biophysical model <file:///home/jared/MatsenGroup/Projects/multidms/multidms/docs/_build/html/biophysical_model.html>`_ section.
+- A concise description of the joint modeling approach is available in the `biophysical model <https://matsengrp.github.io/multidms/biophysical_model.html>`_ section.
 
-- A quick intro to the python interface is available in the `Fit Delta BA.1 example <file:///home/jared/MatsenGroup/Projects/multidms/multidms/docs/_build/html/fit_delta_BA1_example.html>`_ page.
+- A quick intro to the python interface is available in the `Fit Delta BA.1 example <https://matsengrp.github.io/multidms/fit_delta_BA1_example.html>`_ page.
 
 - For a more advanced example of the multidms interface, see our `manuscript SARS-CoV-2 spike analysis <https://matsengrp.github.io/SARS-CoV-2_spike_multidms/spike-analysis.html>`_.
 


### PR DESCRIPTION
I Accidentally added the wrong hyperlinks for biophysical docs and example pipeline - this patches those.