### PR TITLE
patched sorting bug

### DIFF
--- a/multidms/data.py
+++ b/multidms/data.py
@@ -501,9 +501,7 @@ class Data:
                 times_seen = times_seen.astype(int)
             times_seen.index.name = "mutation"
             times_seen.name = f"times_seen_{condition}"
-            mut_df = mut_df.merge(
-                times_seen, left_on="mutation", right_on="mutation", how="outer"
-            ).fillna(0)
+            mut_df = mut_df.merge(times_seen, on="mutation", how="left").fillna(0)
 
         self._mutations_df = mut_df
         self._name = name if isinstance(name, str) else f"Data-{Data.counter}"

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -500,6 +500,18 @@ class Model:
                 inplace=True,
             )
 
+        # make sure the mutations_df matches the binarymaps
+        for condition in self.data.conditions:
+            assert onp.all(
+                mutations_df.index.values == self.data.binarymaps[condition].all_subs
+            ), f"mutations_df does not match binarymaps for condition {condition}"
+
+        # make sure the indices into the bmap are ordered 0-n
+        for i, sub in enumerate(mutations_df.index.values):
+            assert sub == self.data.binarymaps[self.data.reference].i_to_sub(
+                i
+            ), f"mutation {sub} df index does not match binarymaps respective index"
+
         # for effect calculation
         if phenotype_as_effect:
             wildtype_df = self.wildtype_df

--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -168,7 +168,8 @@ def fit_one_model(
     del fit_attributes["dataset"]
     del fit_attributes["verbose"]
 
-    fit_attributes["step_loss"] = onp.zeros(num_training_steps)
+    fit_attributes["step_loss"] = onp.zeros(num_training_steps + 1)
+    fit_attributes["step_loss"][0] = float(imodel.loss)
     fit_attributes["dataset_name"] = dataset.name
     fit_attributes["model"] = imodel
 
@@ -199,7 +200,7 @@ def fit_one_model(
         if onp.isnan(float(imodel.loss)):
             break
 
-        fit_attributes["step_loss"][training_step] = float(imodel.loss)
+        fit_attributes["step_loss"][training_step + 1] = float(imodel.loss)
 
         if verbose:
             print(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -60,7 +60,7 @@ def test_site_integrity():
 def test_bmap_mut_df_order():
     """
     Assert that the binarymap rows and columns match
-    mutations_df indicies exactly.
+    mutations_df indices exactly.
     """
     mut_df = data.mutations_df
     for condition in data.conditions:
@@ -124,14 +124,14 @@ def test_invalid_non_identical_sites():
         assert data.reference_sequence_conditions == ["a", "b"]
 
 
-def test_converstion_from_subs():
+def test_conversion_from_subs():
     """Make sure that the conversion from each reference choice is correct"""
     for ref, bundle in zip(["a", "b"], ["G3P", "P3G"]):
         data = multidms.Data(TEST_FUNC_SCORES, reference=ref)
         assert data.convert_subs_wrt_ref_seq(("b" if ref == "a" else "a"), "") == bundle
 
 
-def test_wildtype_mutatant_predictions():
+def test_wildtype_mutant_predictions():
     """
     test that the wildtype predictions are correct
     by comparing them to a "by-hand" calculation on the parameters.
@@ -244,7 +244,7 @@ def test_non_identical_conversion():
 
 def test_model_PRNGKey():
     """
-    Simply test the instatiation of a model with different PNRG keys
+    Simply test the instantiation of a model with different PRNG keys
     to make sure the seed structure truly ensures the same parameter
     initialization values
     """
@@ -257,7 +257,7 @@ def test_model_PRNGKey():
 def test_lower_bound():
     """
     Make sure that the softplus lower bound is correct
-    by initializing a sofplus activation models and asserting
+    by initializing a softplus activation models and asserting
     predictions never go below the specified lower bound.
     even if that lower bound is high!
 


### PR DESCRIPTION
This addresses an issue that was brought up in #128. 

## Problem

For context, [`multidms.Model.get_mutations_df()`](https://github.com/matsengrp/multidms/blob/9558fe25928abb4e7e454a230ede0cb73b82a643/multidms/model.py#L459) assumes that rows (substitutions) from [`Data.mutations_df`](https://github.com/matsengrp/multidms/blob/9558fe25928abb4e7e454a230ede0cb73b82a643/multidms/model.py#L495) are [ordered identically to `binarymap.all_subs`](https://github.com/matsengrp/multidms/blob/9558fe25928abb4e7e454a230ede0cb73b82a643/tests/test_data.py#L60) when making model predictions with the [identity matrix](https://github.com/matsengrp/multidms/blob/9558fe25928abb4e7e454a230ede0cb73b82a643/multidms/model.py#L509) -- a slightly faster way / simpler way to get a one-hot encoding all mutation specific parameters.

In `pandas<=2.1.4`, there was a ["bug"](https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#notable-bug-fixes) that preserved this ordering - even when I was [merging "times seen" columns](https://github.com/matsengrp/multidms/blob/9558fe25928abb4e7e454a230ede0cb73b82a643/multidms/data.py#L504) during `multidms.Data` object instantiation. With the bug fix in `2.2.0`, the mutations_df join keys got sorted in lexicographical order, thus, the inferred parameter values we're all misaligned.

## Solution

Simply change the merging operation `how="left"`. This fixes all unit tests for me, and is the more correct merge approach for joining new data to a reference df, anyway. 

Of course we could get rid of the identity matrix approach for predictions and simply use `BinaryMap.sub_to_i()`, but I don't see an issue with keeping it. For safe measure, this PR moves the previous unit tests into the `Model.get_mutation_df()` method so this  can be more easily caught if it does cause problems in the future.