### PR TITLE
added logging suppressor for falling back to cpu

### DIFF
--- a/.github/workflows/build_test_package.yml
+++ b/.github/workflows/build_test_package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, "3.10", 3.11]  # quoted 3.10 needed due to this bug: https://github.com/actions/runner/issues/1989
+        python-version: [3.9, "3.10", 3.11, 3.12]  # quoted 3.10 needed due to this bug: https://github.com/actions/runner/issues/1989
 
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/build_test_package.yml
+++ b/.github/workflows/build_test_package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.9, "3.10", 3.11, 3.12]  # quoted 3.10 needed due to this bug: https://github.com/actions/runner/issues/1989
+        python-version: [3.9, "3.10", 3.11]  # quoted 3.10 needed due to this bug: https://github.com/actions/runner/issues/1989
 
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/publish_package_pypi.yml
+++ b/.github/workflows/publish_package_pypi.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,8 +8,6 @@
 # add sourcecode to path
 import sys, os
 
-# sys.path.insert(0, os.path.abspath("../multidms"))
-# sys.path.insert(0, "{0}/..".format(os.path.abspath(".")))
 sys.path.insert(0, "{}/..".format(os.path.abspath(".")))
 
 # -- Project information -----------------------------------------------------
@@ -33,9 +31,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.githubpages",
     "sphinxcontrib.bibtex",
-    # "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
-    # "matplotlib.sphinxext.plot_directive",
     "nbsphinx",
     "nbsphinx_link",
 ]

--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -13,9 +13,19 @@ import pprint
 import multidms
 
 import pandas as pd
+import jax
 import jax.numpy as jnp
 import numpy as onp
 import altair as alt
+
+import logging
+
+logging.getLogger("jax._src.xla_bridge").addFilter(
+    logging.Filter(
+        "An NVIDIA GPU may be present on this machine, "
+        "but a CUDA-enabled jaxlib is not installed. Falling back to cpu."
+    )
+)
 
 
 PARAMETER_NAMES_FOR_PLOTTING = {

--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -13,7 +13,6 @@ import pprint
 import multidms
 
 import pandas as pd
-import jax
 import jax.numpy as jnp
 import numpy as onp
 import altair as alt

--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -931,10 +931,9 @@ class ModelCollection:
             .assign(mut_type=lambda x: x.mutation.apply(mut_type))
             .reset_index()
             .groupby(by=feature_cols)
-            .apply(
-                sparsity, include_groups=True
-            )  # TODO This throws deprecation warning
-            .drop(columns=feature_cols + ["mutation"])
+            # .apply(sparsity, include_groups=True)
+            .apply(sparsity, include_groups=False)
+            # .drop(columns=feature_cols + ["mutation"])
             .reset_index(drop=False)
             .melt(id_vars=feature_cols, var_name="mut_param", value_name="sparsity")
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ keywords = [
 requires-python = ">=3.8"
 dependencies = [
     "polyclonal",
-    "jax",
+    "jax[cpu]==0.4.24",
     "jaxopt",
     "typing_extensions",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
 ]
 keywords = [
     "multidms", 
@@ -32,7 +33,7 @@ keywords = [
 
 
 # Software Dependencies
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "polyclonal",
     "jax[cpu]==0.4.24",


### PR DESCRIPTION
This PR cleans up the 
```
An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.
```
warning, as `multidms` runs on cpu devices by default - and this warning is quite annoying when spawning manu independent training processes.