### PR TITLE
Added optional fista acceleration, and convergence property to models

### DIFF
--- a/multidms/model.py
+++ b/multidms/model.py
@@ -972,6 +972,7 @@ class Model:
         maxiter=1000,
         acceleration=True,
         lock_params={},
+        warn_unconverged=True,
         **kwargs,
     ):
         r"""
@@ -991,6 +992,11 @@ class Model:
             Dictionary of parameters, and desired value to constrain
             them at during optimization. By default, none of the parameters
             besides the reference shift, and reference latent offset are locked.
+        warn_unconverged : bool
+            If True, raise a warning if the optimization does not converge.
+            convergence is defined by whether the model tolerance (''tol'') threshold
+            was passed during the optimization process.
+            Defaults to True.
         **kwargs : dict
             Additional keyword arguments passed to the objective function.
             These include hyperparameters like a ridge penalty on beta, shift, and gamma
@@ -1036,7 +1042,14 @@ class Model:
             **kwargs,
         )
 
-        self._converged = self._state.error < tol
+        converged = self._state.error < tol
+        if not converged and warn_unconverged:
+            warnings.warn(
+                "Model training error did not reach the tolerance threshold. "
+                f"Final error: {self._state.error}, tolerance: {tol}",
+                RuntimeWarning,
+            )
+        self._converged = converged
 
     def plot_pred_accuracy(
         self, hue=True, show=True, saveas=None, annotate_corr=True, ax=None, **kwargs

--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -70,6 +70,7 @@ def fit_one_model(
     tol=1e-4,
     num_training_steps=1,
     iterations_per_step=20000,
+    acceleration=True,
     n_hidden_units=5,
     lower_bound=None,
     PRNGKey=0,
@@ -113,7 +114,7 @@ def fit_one_model(
         The initial value of the beta_naught parameter. The default is 0.0.
         Note that is lock_beta_naught is not None, then this value is irrelevant.
     tol : float, optional
-        The tolerance for the fit. The default is 1e-3.
+        The tolerance for the fit. The default is 1e-4.
     num_training_steps : int, optional
         The number of training steps to perform. The default is 1.
         If you would like to see training loss throughout training,
@@ -125,6 +126,9 @@ def fit_one_model(
         with the loss at the beginning each step.
     iterations_per_step : int, optional
         The number of iterations to perform per training step. The default is 20000.
+    acceleration : bool, optional
+        Whether to use the FISTA acceleration. The default is True. This is only useful
+        when using a single step with many iterations.
     n_hidden_units : int, optional
         The number of hidden units to use in the neural network model. The default is 5.
     lower_bound : float, optional
@@ -195,6 +199,7 @@ def fit_one_model(
             lasso_shift=scale_coeff_lasso_shift,
             maxiter=iterations_per_step,
             tol=tol,
+            acceleration=acceleration,
             huber_scale=huber_scale_huber,
             lock_params=lock_params,
             scale_coeff_ridge_shift=scale_coeff_ridge_shift,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,14 +12,6 @@ import numpy as np
 import pandas as pd
 from io import StringIO
 
-# def warn_with_traceback(message, category, filename, lineno, file=None, line=None):
-
-#     log = file if hasattr(file,'write') else sys.stderr
-#     traceback.print_stack(file=log)
-#     log.write(warnings.formatwarning(message, category, filename, lineno, line))
-
-# warnings.showwarning = warn_with_traceback
-
 TEST_FUNC_SCORES = pd.read_csv(
     StringIO(
         """
@@ -522,8 +514,8 @@ def test_single_vs_multistep_acceleration():
     """
     We currently approach the model optimization problem with
     a multi-step approach, where each step re-initializes the jaxopt.ProximalGradient
-    objects before fitting the latest parameters from the previous step for some number of
-    iterations per step. This behavior affects the FISTA acceleration, which is
+    objects before fitting the latest parameters from the previous step for some number
+    of iterations per step. This behavior affects the FISTA acceleration, which is
     re-set at each step. We want to make sure that the multi-step approach
     is identical to a single step if we are remove the acceleration.
     """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -148,7 +148,7 @@ def test_wildtype_mutant_predictions():
         assert_site_integrity=False,
     )
     model = multidms.Model(data, PRNGKey=23)
-    model.fit(maxiter=2)
+    model.fit(maxiter=2, warn_unconverged=False)
     wildtype_df = model.wildtype_df
     for condition in model.data.conditions:
         byhand_latent = model.params["beta_naught"][0]
@@ -189,7 +189,7 @@ def test_mutations_df():
         assert_site_integrity=False,
     )
     model = multidms.Model(data, PRNGKey=23)
-    model.fit(maxiter=2)
+    model.fit(maxiter=2, warn_unconverged=False)
     sig_params = model.params["theta"]
     scale, bias = sig_params["ge_scale"], sig_params["ge_bias"]
     mutations_df = model.get_mutations_df(phenotype_as_effect=False)
@@ -348,8 +348,8 @@ def test_model_fit_and_determinism():
     model_1 = multidms.Model(data, PRNGKey=23)
     model_2 = multidms.Model(data, PRNGKey=23)
 
-    model_1.fit(maxiter=5)
-    model_2.fit(maxiter=5)
+    model_1.fit(maxiter=5, warn_unconverged=False)
+    model_2.fit(maxiter=5, warn_unconverged=False)
 
     for param, values in model_1.params.items():
         assert np.all(values == model_2.params[param])
@@ -438,7 +438,7 @@ def test_model_get_df_loss():
     when given the training dataframe.
     """
     model = multidms.Model(data, PRNGKey=23)
-    model.fit(maxiter=2)
+    model.fit(maxiter=2, warn_unconverged=False)
     loss = model.loss
     df_loss = model.get_df_loss(TEST_FUNC_SCORES)
     assert loss == df_loss
@@ -457,7 +457,7 @@ def test_model_get_df_loss_conditional():
     they match the total loss.
     """
     model = multidms.Model(data, PRNGKey=23)
-    model.fit(maxiter=2)
+    model.fit(maxiter=2, warn_unconverged=False)
     loss = model.loss
     df_loss = model.get_df_loss(TEST_FUNC_SCORES, conditional=True)
     # remove full and compare sum of the rest
@@ -473,7 +473,7 @@ def test_conditional_loss():
     when given the training dataframe.
     """
     model = multidms.Model(data, PRNGKey=23)
-    model.fit(maxiter=2)
+    model.fit(maxiter=2, warn_unconverged=False)
     loss = model.conditional_loss
     df_loss = model.get_df_loss(TEST_FUNC_SCORES, conditional=True)
     assert loss == df_loss
@@ -520,10 +520,10 @@ def test_single_vs_multistep_acceleration():
     is identical to a single step if we are remove the acceleration.
     """
     model = multidms.Model(data, PRNGKey=23)
-    model.fit(maxiter=4, acceleration=False)
+    model.fit(maxiter=4, acceleration=False, warn_unconverged=False)
     loss = model.loss
     model = multidms.Model(data, PRNGKey=23)
     for i in range(2):
-        model.fit(maxiter=2, acceleration=False)
+        model.fit(maxiter=2, acceleration=False, warn_unconverged=False)
     loss_no_accel = model.loss
     assert loss == loss_no_accel


### PR DESCRIPTION
This PR addresses #137 by:

* adding the optimizer state as a property to the `Model` object that get's updated for each call to the `fit()`.
* adding the `converged` property, which returns a boolean representing whether the tolerance threshold was reached during the last call to `.fit()` method.

TODO:

- [x] Add "converged" feature to model collection class dataframe
- [x] raise warning in `Model.fit` if not converged
- [x] `fit_models` should return the number of models that have converged, rather than "number that didn't throw an error"