### PR TITLE
Allow warmstart initialization without count data

### DIFF
--- a/multidms/jaxmodels.py
+++ b/multidms/jaxmodels.py
@@ -155,18 +155,17 @@ class Latent(eqx.Module):
         Returns:
             Latent model initialized with warmstart parameters.
         """
-        if data.pre_counts is None:
-            raise ValueError(
-                "Warmstart requires pre_counts data. Either provide count data "
-                "or disable warmstart by setting warmstart=False."
-            )
         X = scipy.sparse.csr_array(
             (data.X.data, (data.X.indices[:, 0], data.X.indices[:, 1])),
             shape=(data.X.shape[0], len(data.x_wt)),
         )
         y = data.functional_scores
         ridge_solver = linear_model.Ridge(alpha=l2reg)
-        ridge_solver.fit(X, y, sample_weight=jnp.log(data.pre_counts))
+
+        if data.pre_counts is not None:
+            ridge_solver.fit(X, y, sample_weight=jnp.log(data.pre_counts))
+        else:
+            ridge_solver.fit(X, y)
         return Latent(
             β0=ridge_solver.intercept_,
             β=ridge_solver.coef_,

--- a/tests/test_jaxmodels.py
+++ b/tests/test_jaxmodels.py
@@ -92,6 +92,18 @@ def single_condition_data(
 
 
 @pytest.fixture
+def single_condition_data_no_counts(
+    wildtype_sequence, sparse_variant_matrix, functional_scores
+):
+    """Create a Data object without count data (functional scores only)."""
+    return jaxmodels.Data(
+        x_wt=wildtype_sequence,
+        X=sparse_variant_matrix,
+        functional_scores=functional_scores,
+    )
+
+
+@pytest.fixture
 def multi_condition_data(n_conditions, n_mutations, n_variants, rng_key):
     """Create Data objects for multiple conditions."""
     data_sets = {}
@@ -206,6 +218,12 @@ class TestLatent:
         """Test warmstart initialization."""
         latent = jaxmodels.Latent.warmstart(single_condition_data, l2reg=0.1)
         assert latent.β.shape == single_condition_data.x_wt.shape
+        assert latent.β0.shape == ()
+
+    def test_latent_warmstart_without_counts(self, single_condition_data_no_counts):
+        """Test warmstart works with functional scores only (no counts)."""
+        latent = jaxmodels.Latent.warmstart(single_condition_data_no_counts, l2reg=0.1)
+        assert latent.β.shape == single_condition_data_no_counts.x_wt.shape
         assert latent.β0.shape == ()
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -176,9 +176,10 @@ def test_model_fit_with_identity_ge(simple_data):
 
 
 def test_model_fit_with_warmstart(simple_data):
-    """Test fitting with warmstart enabled (requires count data)."""
-    # Skip this test for now - warmstart requires count data
-    pytest.skip("Warmstart requires count data which test data doesn't have")
+    """Test fitting with warmstart enabled (no count data needed)."""
+    model = multidms.Model(simple_data)
+    model.fit(warmstart=True, maxiter=3)
+    assert model.params is not None
 
 
 def test_model_fit_without_warmstart(simple_data):


### PR DESCRIPTION
## Summary

- Make `sample_weight` conditional in `Latent.warmstart()`: use `log(pre_counts)` when available, uniform weighting otherwise
- Removes the `ValueError` guard that forced `warmstart=False` for functional-score-only datasets
- Un-skips `test_model_fit_with_warmstart` which was blocked by this limitation

## Test plan

- [x] New unit test: `test_latent_warmstart_without_counts` — verifies `Latent.warmstart()` works without count data
- [x] Un-skipped integration test: `test_model_fit_with_warmstart` — verifies `Model.fit(warmstart=True)` on functional-score-only data
- [x] Existing test `test_latent_warmstart` — confirms count-weighted path unchanged
- [x] All 80 tests pass, linting and formatting clean

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)