### PR TITLE
Refactor convergence trajectory & harmonize loss APIs

### DIFF
--- a/multidms/jaxmodels.py
+++ b/multidms/jaxmodels.py
@@ -21,6 +21,7 @@ import abc
 
 import jaxopt
 
+import pandas as pd
 import scipy
 from sklearn import linear_model
 
@@ -371,7 +372,7 @@ def fit(
     alpha_init: dict[str, Float] | None = None,
     beta_clip_range: tuple[Float, Float] | None = None,
     verbose: bool = True,
-) -> tuple[Model, list[float]]:
+) -> tuple[Model, pd.DataFrame]:
     r"""
     Fit a model to data.
 
@@ -410,7 +411,9 @@ def fit(
                 If False, suppresses all print output.
 
     Returns:
-        Tuple of (fitted model, loss trajectory).
+        Tuple of (fitted model, convergence trajectory DataFrame) with columns:
+        ``iteration``, ``objective_total_trajectory``,
+        ``objective_error_trajectory``, ``loss_trajectory``.
     """
     if data_sets[reference_condition].x_wt.sum() != 0:
         raise ValueError(
@@ -568,8 +571,8 @@ def fit(
         )
     )
 
-    # track loss trajectory
-    loss_trajectory = []
+    # track convergence trajectory
+    trajectory_rows = []
 
     try:
         for k in range(block_iters):
@@ -712,8 +715,17 @@ def fit(
             if verbose:
                 print(f"  {objective_error=:.2e}")
 
-            # store loss for trajectory
-            loss_trajectory.append(float(obj))
+            # store trajectory data
+            trajectory_rows.append(
+                {
+                    "iteration": k,
+                    "objective_total_trajectory": float(obj * scale),
+                    "objective_error_trajectory": float(objective_error),
+                    "loss_trajectory": float(
+                        sum(loss_fn(model, data_sets, **loss_kwargs).values())
+                    ),
+                }
+            )
 
             if (
                 state_calibration.error < opt_calibration.tol
@@ -727,4 +739,15 @@ def fit(
     except KeyboardInterrupt:
         pass
 
-    return model, loss_trajectory
+    if len(trajectory_rows) == 0:
+        convergence_trajectory_df = pd.DataFrame(
+            columns=[
+                "iteration",
+                "objective_total_trajectory",
+                "objective_error_trajectory",
+                "loss_trajectory",
+            ]
+        )
+    else:
+        convergence_trajectory_df = pd.DataFrame(trajectory_rows)
+    return model, convergence_trajectory_df

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -87,7 +87,7 @@ class Model:
         # Will be populated by fit()
         self._jax_model = None
         self._jax_data_sets = None
-        self._loss_trajectory = None
+        self._convergence_trajectory_df = None
         self._fit_tol = None
         self._loss_fn = None
         self._loss_kwargs = None
@@ -108,61 +108,35 @@ class Model:
     def converged(self) -> bool:
         """Whether the model fitting converged.
 
-        Convergence is determined by whether the relative change in the
-        objective function between the last two block coordinate descent
-        iterations was below the tolerance used during fitting.
+        Convergence is determined by whether the objective error
+        (relative change in the objective function) at the last iteration
+        was below the tolerance used during fitting.
         """
-        if self._loss_trajectory is None or len(self._loss_trajectory) < 2:
+        if (
+            self._convergence_trajectory_df is None
+            or len(self._convergence_trajectory_df) == 0
+        ):
             return False
-        last_two = self._loss_trajectory[-2:]
-        error = abs(last_two[-1] - last_two[-2]) / max(
-            abs(last_two[-1]), abs(last_two[-2]), 1
+        return (
+            float(
+                self._convergence_trajectory_df["objective_error_trajectory"].iloc[-1]
+            )
+            < self._fit_tol
         )
-        return error < self._fit_tol
-
-    @property
-    def conditional_loss(self) -> dict:
-        """Per-condition loss on training data.
-
-        Returns
-        -------
-        dict[str, float]
-            Dictionary mapping condition names to their training loss values.
-
-        Raises
-        ------
-        ValueError
-            If model has not been fitted.
-        """
-        if self._jax_model is None:
-            raise ValueError("Model has not been fitted. Call fit() first.")
-        loss_dict = self._loss_fn(
-            self._jax_model, self._jax_data_sets, **self._loss_kwargs
-        )
-        return {k: float(v) for k, v in loss_dict.items()}
 
     @property
     def convergence_trajectory_df(self) -> pd.DataFrame:
         """
-        Convergence trajectory showing loss over iterations.
+        Convergence trajectory showing objective and loss over iterations.
 
         Returns
         -------
         pd.DataFrame
-            DataFrame with columns 'iteration', 'loss', 'error'
+            DataFrame with columns ``iteration``,
+            ``objective_total_trajectory``, ``objective_error_trajectory``,
+            ``loss_trajectory``.
         """
-        if self._loss_trajectory is None:
-            return None
-
-        df = pd.DataFrame(
-            {
-                "iteration": range(len(self._loss_trajectory)),
-                "loss": self._loss_trajectory,
-            }
-        )
-        # Calculate error as change in loss
-        df["error"] = df["loss"].diff().abs().fillna(0.0)
-        return df
+        return self._convergence_trajectory_df
 
     # See issue #178 for optimization of re-fitting already fitted models
     def fit(
@@ -249,7 +223,7 @@ class Model:
         self._loss_kwargs = loss_kwargs
 
         # Fit model using jaxmodels
-        self._jax_model, self._loss_trajectory = jaxmodels.fit(
+        self._jax_model, self._convergence_trajectory_df = jaxmodels.fit(
             data_sets=self._jax_data_sets,
             reference_condition=self._data.reference,
             l2reg=self._l2reg,
@@ -527,7 +501,31 @@ class Model:
 
         return result
 
-    def get_df_loss(self, df, conditional=False):
+    @property
+    def training_loss(self) -> dict:
+        """Per-condition and total loss on training data.
+
+        Returns
+        -------
+        dict[str, float]
+            Dictionary mapping condition names and ``"total"`` to their
+            training loss values.
+
+        Raises
+        ------
+        ValueError
+            If model has not been fitted.
+        """
+        if self._jax_model is None:
+            raise ValueError("Model has not been fitted. Call fit() first.")
+        loss_dict = self._loss_fn(
+            self._jax_model, self._jax_data_sets, **self._loss_kwargs
+        )
+        result = {k: float(v) for k, v in loss_dict.items()}
+        result["total"] = sum(result.values())
+        return result
+
+    def eval_loss(self, df):
         """Evaluate the model's loss on an arbitrary DataFrame.
 
         Parameters
@@ -535,14 +533,11 @@ class Model:
         df : pd.DataFrame
             DataFrame with columns 'condition', 'aa_substitutions',
             'func_score'.
-        conditional : bool
-            If True, return per-condition loss as a dict.
-            If False, return the total (summed) loss as a float.
 
         Returns
         -------
-        dict[str, float] or float
-            Per-condition losses if conditional=True, else total loss.
+        dict[str, float]
+            Per-condition losses and ``"total"`` loss.
 
         Raises
         ------
@@ -569,10 +564,9 @@ class Model:
 
         loss_dict = self._loss_fn(self._jax_model, temp_data_sets, **self._loss_kwargs)
 
-        if conditional:
-            return {k: float(v) for k, v in loss_dict.items()}
-        else:
-            return float(sum(loss_dict.values()))
+        result = {k: float(v) for k, v in loss_dict.items()}
+        result["total"] = sum(result.values())
+        return result
 
     def add_phenotypes_to_df(
         self,

--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -454,8 +454,7 @@ class ModelCollection:
             bool
         )
         for idx, fit in fit_models.iterrows():
-            conditional_loss = fit.model.conditional_loss
-            for condition, loss in conditional_loss.items():
+            for condition, loss in fit.model.training_loss.items():
                 fit_models.loc[idx, f"{condition}_loss_training"] = loss
 
         self._site_map_union = site_map_union
@@ -609,15 +608,15 @@ class ModelCollection:
 
         return ret
 
-    def add_validation_loss(self, test_data, overwrite=False):
+    def add_eval_loss(self, test_data, overwrite=False):
         """
-        Add validation loss to the fit collection dataframe.
+        Add evaluation (validation) loss to the fit collection dataframe.
 
         Parameters
         ----------
         test_data : pd.DataFrame or dict(str, pd.DataFrame)
             The testing dataframe to compute validation loss with respect to,
-            must have columns "aa_substitutitions", "condition", and "func_score".
+            must have columns "aa_substitutions", "condition", and "func_score".
             If a dictionary is passed, there should be a key for
             each unique dataset_name factor in the self.fit_models dataframe
             - with the value being the respective testing dataframe.
@@ -627,8 +626,7 @@ class ModelCollection:
 
         Returns
         -------
-        pd.DataFrame
-            The self.fit_models dataframe with the validation loss added.
+        None
         """
         if isinstance(test_data, pd.DataFrame):
             temp_test_data = test_data.copy()
@@ -639,10 +637,11 @@ class ModelCollection:
         # check there's a testing dataframe for each unique dataset_name
         assert set(test_data.keys()) == set(self.fit_models["dataset_name"].unique())
 
+        all_loss_keys = list(self.conditions) + ["total"]
         validation_cols_exist = onp.any(
             [
-                f"{condition}_loss_validation" in self.fit_models.columns
-                for condition in self.conditions
+                f"{key}_loss_validation" in self.fit_models.columns
+                for key in all_loss_keys
             ]
         )
         if validation_cols_exist and not overwrite:
@@ -652,30 +651,24 @@ class ModelCollection:
             )
 
         self.fit_models = self.fit_models.assign(
-            **{
-                f"{condition}_loss_validation": onp.nan for condition in self.conditions
-            },
-            total_loss_validation=onp.nan,
+            **{f"{key}_loss_validation": onp.nan for key in all_loss_keys},
         )
 
         for idx, fit in self.fit_models.iterrows():
-            condional_df_loss = fit.model.get_df_loss(
-                test_data[fit["dataset_name"]], conditional=True
-            )
-            for condition, loss in condional_df_loss.items():
-                self.fit_models.loc[idx, f"{condition}_loss_validation"] = loss
-            self.fit_models.loc[idx, "total_loss_validation"] = sum(
-                condional_df_loss.values()
-            )
+            eval_loss = fit.model.eval_loss(test_data[fit["dataset_name"]])
+            for key, loss in eval_loss.items():
+                self.fit_models.loc[idx, f"{key}_loss_validation"] = loss
 
         return None
 
-    def get_conditional_loss_df(self, query=None):
+    def loss_df(self, query=None):
         """
         Return a long form dataframe with columns
         "dataset_name", "fusionreg",
         "split" ("training" or "validation"),
         "loss" (actual value), and "condition".
+
+        The ``condition`` column includes ``"total"`` for the summed loss.
 
         Parameters
         ----------

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -199,8 +199,9 @@ def test_model_fit_convergence_trajectory(simple_data):
     assert traj_df is not None
     assert isinstance(traj_df, pd.DataFrame)
     assert "iteration" in traj_df.columns
-    assert "loss" in traj_df.columns
-    assert "error" in traj_df.columns
+    assert "objective_total_trajectory" in traj_df.columns
+    assert "objective_error_trajectory" in traj_df.columns
+    assert "loss_trajectory" in traj_df.columns
     assert len(traj_df) > 0
 
 

--- a/tests/test_model_collection.py
+++ b/tests/test_model_collection.py
@@ -403,6 +403,7 @@ class TestModelCollectionInit:
     def test_training_loss_columns(self, collection):
         for condition in collection.conditions:
             assert f"{condition}_loss_training" in collection.fit_models.columns
+        assert "total_loss_training" in collection.fit_models.columns
 
     def test_condition_colors(self, collection):
         assert isinstance(collection.condition_colors, dict)
@@ -530,48 +531,48 @@ class TestSplitApplyCombineMuts:
 # ========== add_validation_loss tests ==========
 
 
-class TestAddValidationLoss:
-    """Tests for ModelCollection.add_validation_loss()."""
+class TestAddEvalLoss:
+    """Tests for ModelCollection.add_eval_loss()."""
 
     def test_adds_validation_columns(self, fit_models_df):
         mc = ModelCollection(fit_models_df.copy())
-        mc.add_validation_loss(TEST_VALIDATION_SCORES)
+        mc.add_eval_loss(TEST_VALIDATION_SCORES)
         for condition in mc.conditions:
             assert f"{condition}_loss_validation" in mc.fit_models.columns
 
     def test_total_loss_validation(self, fit_models_df):
         mc = ModelCollection(fit_models_df.copy())
-        mc.add_validation_loss(TEST_VALIDATION_SCORES)
+        mc.add_eval_loss(TEST_VALIDATION_SCORES)
         assert "total_loss_validation" in mc.fit_models.columns
         assert mc.fit_models["total_loss_validation"].notna().all()
 
     def test_dict_input(self, fit_models_df):
         mc = ModelCollection(fit_models_df.copy())
         test_dict = {"test_data": TEST_VALIDATION_SCORES}
-        mc.add_validation_loss(test_dict)
+        mc.add_eval_loss(test_dict)
         assert "total_loss_validation" in mc.fit_models.columns
 
     def test_overwrite_false_raises(self, fit_models_df):
         mc = ModelCollection(fit_models_df.copy())
-        mc.add_validation_loss(TEST_VALIDATION_SCORES)
+        mc.add_eval_loss(TEST_VALIDATION_SCORES)
         with pytest.raises(ValueError, match="overwrite"):
-            mc.add_validation_loss(TEST_VALIDATION_SCORES, overwrite=False)
+            mc.add_eval_loss(TEST_VALIDATION_SCORES, overwrite=False)
 
     def test_overwrite_true_works(self, fit_models_df):
         mc = ModelCollection(fit_models_df.copy())
-        mc.add_validation_loss(TEST_VALIDATION_SCORES)
-        mc.add_validation_loss(TEST_VALIDATION_SCORES, overwrite=True)
+        mc.add_eval_loss(TEST_VALIDATION_SCORES)
+        mc.add_eval_loss(TEST_VALIDATION_SCORES, overwrite=True)
         assert mc.fit_models["total_loss_validation"].notna().all()
 
 
 # ========== get_conditional_loss_df tests ==========
 
 
-class TestGetConditionalLossDf:
-    """Tests for ModelCollection.get_conditional_loss_df()."""
+class TestLossDf:
+    """Tests for ModelCollection.loss_df()."""
 
     def test_returns_correct_columns(self, collection):
-        df = collection.get_conditional_loss_df()
+        df = collection.loss_df()
         assert "dataset_name" in df.columns
         assert "fusionreg" in df.columns
         assert "condition" in df.columns
@@ -579,17 +580,17 @@ class TestGetConditionalLossDf:
         assert "split" in df.columns
 
     def test_training_only_rows(self, collection):
-        df = collection.get_conditional_loss_df()
+        df = collection.loss_df()
         assert set(df["split"].unique()) == {"training"}
 
     def test_with_validation_loss(self, fit_models_df):
         mc = ModelCollection(fit_models_df.copy())
-        mc.add_validation_loss(TEST_VALIDATION_SCORES)
-        df = mc.get_conditional_loss_df()
+        mc.add_eval_loss(TEST_VALIDATION_SCORES)
+        df = mc.loss_df()
         assert "validation" in df["split"].values
 
     def test_query_filtering(self, collection):
-        df = collection.get_conditional_loss_df(query="fusionreg == 0.0")
+        df = collection.loss_df(query="fusionreg == 0.0")
         assert all(df["fusionreg"] == 0.0)
 
 


### PR DESCRIPTION
## Summary

Closes #195.

- **`jaxmodels.fit()`** now returns a DataFrame (instead of `list[float]`) with columns: `iteration`, `objective_total_trajectory` (unscaled), `objective_error_trajectory`, and `loss_trajectory` (actual loss without regularization)
- **`Model.conditional_loss`** → **`Model.training_loss`**: now includes a `"total"` key
- **`Model.get_df_loss`** → **`Model.eval_loss`**: always returns `{condition: val, "total": val}` dict (removed `conditional` parameter)
- **`Model.convergence_trajectory_df`**: simplified to return the stored DataFrame directly
- **`Model.converged`**: reads `objective_error_trajectory` from the DataFrame
- **`ModelCollection.add_validation_loss`** → **`ModelCollection.add_eval_loss`**
- **`ModelCollection.get_conditional_loss_df`** → **`ModelCollection.loss_df`**

## Test plan

- [x] All 153 tests pass (`pixi run pytest --doctest-modules multidms tests -vv`)
- [x] Ruff and Black checks pass
- [ ] CI passes on all Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)