### PR TITLE
Consolidate installation docs into single source of truth

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -61,27 +61,12 @@ These can include:
 
   - unit tests in the `./tests/ <tests>`_ subdirectory
 
-Using pixi for development
-+++++++++++++++++++++++++++
-You can optionally use `pixi <https://pixi.sh>`_ for declarative environment management::
-
-    pixi install          # creates env, installs all deps + editable package
-    pixi run test         # pytest with doctests
-    pixi run lint         # ruff
-    pixi run fmt          # black
-
-To test against a specific Python version::
-
-    pixi run -e py39 test
-
-This is equivalent to the manual ``pip install -e ".[dev]"`` workflow
-described below — both approaches are fully supported.
-
 Running the tests locally
 ++++++++++++++++++++++++++
 After you make changes, you should run two sets of tests.
-To run the tests, go to the top-level packag directory -
-making sure to install and activate a `development environment <https://matsengrp.github.io/multidms/installation.html>`_.
+To run the tests, go to the top-level package directory —
+making sure to install a
+`development environment <https://matsengrp.github.io/multidms/installation.html#developer-install>`_.
 
 Then use ruff_ to `lint the code <https://en.wikipedia.org/wiki/Lint_%28software%29>`_ by running::
 

--- a/README.md
+++ b/README.md
@@ -24,29 +24,6 @@ To contribute to this package, read the instructions in [CONTRIBUTING.rst](CONTR
 
 ## Development
 
-### Option A: pixi (recommended)
-
-[pixi](https://pixi.sh) provides declarative, one-command environment setup with pinned Python versions.
-
-Install pixi ([instructions](https://pixi.sh/latest/#installation)), then:
-
-    pixi install          # creates env, installs all deps + editable package
-    pixi run test         # pytest with doctests
-    pixi run lint         # ruff
-    pixi run fmt          # black
-    pixi run docs         # build Sphinx docs
-
-To test against a specific Python version:
-
-    pixi run -e py39 test
-    pixi run -e py312 test
-
-### Option B: pip
-
-    python -m venv .venv && source .venv/bin/activate
-    pip install -e ".[dev]"
-    pytest --doctest-modules multidms tests
-    ruff check .
-    black .
-
-Both approaches are fully supported. See [CONTRIBUTING.rst](CONTRIBUTING.rst) for more details.
+See the [installation docs](https://matsengrp.github.io/multidms/installation.html)
+for developer setup (pixi and pip workflows), and [CONTRIBUTING.rst](CONTRIBUTING.rst)
+for contribution guidelines.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,30 +1,54 @@
 Installation
 ============
 
-``multidms`` requires Python 3.8 or higher.
+``multidms`` requires Python 3.9 or higher.
 
-The source code for ``multidms`` is available on GitHub at https://github.com/matsengrp/multidms.
+The source code is available on GitHub at
+https://github.com/matsengrp/multidms.
 
-The easiest way to install ``multidms`` is using ``pip``:
+Install from PyPI
+-----------------
 
-.. code-block:: 
+.. code-block::
 
    pip install multidms
-
-.. note::
-
-   The `multidms.Model` fitting process can be quite computationally intensive,
-   and if available, we recommend using a GPU to accelerate it.
-   While ``multidms`` ships with ``jax`` and ``jaxlib`` as dependencies,
-   these packages do not include CUDA support by default.
-   For this, please update the jax installation in your environment to include CUDA support
-   by following the instructions in the 
-   `jax documentation <https://github.com/google/jax#pip-installation-gpu-cuda-installed-via-pip-easier>`_.
 
 Developer install
 -----------------
 
-.. code-block:: 
+Option A: pixi (recommended)
++++++++++++++++++++++++++++++
 
-   git clone git@github.com:matsengrp/multidms.git
-   (cd multidms && pip install -e '.[dev]')
+`pixi <https://pixi.sh>`_ provides declarative, one-command environment
+setup with pinned Python versions.
+
+Install pixi (`instructions <https://pixi.sh/latest/#installation>`_),
+then::
+
+    pixi install          # creates env, installs all deps + editable package
+    pixi run test         # pytest with doctests
+    pixi run lint         # ruff
+    pixi run fmt          # black
+    pixi run docs         # build Sphinx docs
+
+To test against a specific Python version::
+
+    pixi run -e py39 test
+    pixi run -e py312 test
+
+Option B: pip
++++++++++++++
+
+::
+
+    git clone git@github.com:matsengrp/multidms.git
+    cd multidms
+    python -m venv .venv && source .venv/bin/activate
+    pip install -e ".[dev]"
+    pytest --doctest-modules multidms tests
+    ruff check .
+    black .
+
+Both approaches are fully supported.
+See `CONTRIBUTING.rst <https://github.com/matsengrp/multidms/blob/main/CONTRIBUTING.rst>`_
+for contribution guidelines.


### PR DESCRIPTION
Closes #203

## Summary

- Makes `docs/installation.rst` the single source of truth for both end-user and developer installation
- Fixes Python version requirement: 3.8 → 3.9 (matching `pyproject.toml`)
- Removes outdated GPU/CUDA note (multi-CPU fitting is faster in practice)
- Adds pixi (recommended) + pip developer workflows to installation page
- Trims `README.md` Development section to link to the docs
- Removes duplicated pixi section from `CONTRIBUTING.rst`

## Test plan

- [x] `pixi run test` — 153 tests pass
- [x] `pixi run lint` — all checks pass
- [x] `pixi run fmt-check` — all files formatted
- [x] `pixi run docs` — Sphinx build succeeds (4 pre-existing warnings in model.py docstrings, unrelated)
- [ ] Verify rendered installation page on docs site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)