### PR TITLE
Record block-level convergence diagnostics in trajectory

### DIFF
--- a/multidms/jaxmodels.py
+++ b/multidms/jaxmodels.py
@@ -411,9 +411,19 @@ def fit(
                 If False, suppresses all print output.
 
     Returns:
-        Tuple of (fitted model, convergence trajectory DataFrame) with columns:
-        ``iteration``, ``objective_total_trajectory``,
-        ``objective_error_trajectory``, ``loss_trajectory``.
+        Tuple of (fitted model, convergence trajectory DataFrame).
+
+        The DataFrame has one row per outer iteration with columns:
+
+        - ``iteration``, ``objective_total_trajectory``,
+          ``objective_error_trajectory``, ``loss_trajectory``,
+          ``loss_per_variant_trajectory``
+        - Block-level diagnostics for each optimization block
+          (``calibration_error``, ``calibration_stepsize``,
+          ``calibration_iter_num``, ``beta0_error``, etc.)
+        - Per-condition parameters: ``alpha_{condition}``,
+          ``theta_{condition}``, ``beta0_{condition}``,
+          ``sparsity_{condition}`` (non-reference only)
     """
     if data_sets[reference_condition].x_wt.sum() != 0:
         raise ValueError(
@@ -572,6 +582,7 @@ def fit(
     )
 
     # track convergence trajectory
+    n_variants_total = sum(data_sets[d].functional_scores.shape[0] for d in data_sets)
     trajectory_rows = []
 
     try:
@@ -716,14 +727,40 @@ def fit(
                 print(f"  {objective_error=:.2e}")
 
             # store trajectory data
+            per_condition = {}
+            for d in model.φ:
+                per_condition[f"alpha_{d}"] = float(model.α[d])
+                per_condition[f"theta_{d}"] = float(jnp.exp(model.logθ[d]))
+                per_condition[f"beta0_{d}"] = float(model.φ[d].β0)
+                if d != model.reference_condition:
+                    per_condition[f"sparsity_{d}"] = float(
+                        (
+                            model.φ[d].β - model.φ[model.reference_condition].β == 0
+                        ).mean()
+                    )
+
+            loss_total = float(sum(loss_fn(model, data_sets, **loss_kwargs).values()))
+
             trajectory_rows.append(
                 {
                     "iteration": k,
                     "objective_total_trajectory": float(obj * scale),
                     "objective_error_trajectory": float(objective_error),
-                    "loss_trajectory": float(
-                        sum(loss_fn(model, data_sets, **loss_kwargs).values())
-                    ),
+                    "loss_trajectory": loss_total,
+                    "loss_per_variant_trajectory": loss_total / n_variants_total,
+                    "calibration_error": float(state_calibration.error),
+                    "calibration_stepsize": float(state_calibration.stepsize),
+                    "calibration_iter_num": int(state_calibration.iter_num),
+                    "beta0_error": float(state_β0.error),
+                    "beta0_stepsize": float(state_β0.stepsize),
+                    "beta0_iter_num": int(state_β0.iter_num),
+                    "beta_nonbundle_error": float(state_nonbundle.error),
+                    "beta_nonbundle_stepsize": float(state_nonbundle.stepsize),
+                    "beta_nonbundle_iter_num": int(state_nonbundle.iter_num),
+                    "beta_bundle_error": float(state_bundle.error),
+                    "beta_bundle_stepsize": float(state_bundle.stepsize),
+                    "beta_bundle_iter_num": int(state_bundle.iter_num),
+                    **per_condition,
                 }
             )
 
@@ -739,14 +776,35 @@ def fit(
     except KeyboardInterrupt:
         pass
 
+    conditions = list(data_sets.keys())
+    base_columns = [
+        "iteration",
+        "objective_total_trajectory",
+        "objective_error_trajectory",
+        "loss_trajectory",
+        "loss_per_variant_trajectory",
+        "calibration_error",
+        "calibration_stepsize",
+        "calibration_iter_num",
+        "beta0_error",
+        "beta0_stepsize",
+        "beta0_iter_num",
+        "beta_nonbundle_error",
+        "beta_nonbundle_stepsize",
+        "beta_nonbundle_iter_num",
+        "beta_bundle_error",
+        "beta_bundle_stepsize",
+        "beta_bundle_iter_num",
+    ]
+    condition_columns = []
+    for d in conditions:
+        condition_columns.extend([f"alpha_{d}", f"theta_{d}", f"beta0_{d}"])
+        if d != reference_condition:
+            condition_columns.append(f"sparsity_{d}")
+
     if len(trajectory_rows) == 0:
         convergence_trajectory_df = pd.DataFrame(
-            columns=[
-                "iteration",
-                "objective_total_trajectory",
-                "objective_error_trajectory",
-                "loss_trajectory",
-            ]
+            columns=base_columns + condition_columns
         )
     else:
         convergence_trajectory_df = pd.DataFrame(trajectory_rows)

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -127,14 +127,18 @@ class Model:
     @property
     def convergence_trajectory_df(self) -> pd.DataFrame:
         """
-        Convergence trajectory showing objective and loss over iterations.
+        Convergence trajectory with diagnostics over iterations.
 
         Returns
         -------
         pd.DataFrame
-            DataFrame with columns ``iteration``,
-            ``objective_total_trajectory``, ``objective_error_trajectory``,
-            ``loss_trajectory``.
+            One row per iteration with columns for overall objective
+            (``iteration``, ``objective_total_trajectory``,
+            ``objective_error_trajectory``, ``loss_trajectory``,
+            ``loss_per_variant_trajectory``), block-level diagnostics
+            (e.g. ``calibration_error``, ``beta0_stepsize``), and
+            per-condition parameters (``alpha_{cond}``, ``theta_{cond}``,
+            ``beta0_{cond}``, ``sparsity_{cond}``).
         """
         return self._convergence_trajectory_df
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -191,18 +191,78 @@ def test_model_fit_without_warmstart(simple_data):
 
 
 def test_model_fit_convergence_trajectory(simple_data):
-    """Test that convergence trajectory is recorded."""
+    """Test that convergence trajectory is recorded with all columns."""
     model = multidms.Model(simple_data)
     model.fit(maxiter=5, warmstart=False)
 
     traj_df = model.convergence_trajectory_df
     assert traj_df is not None
     assert isinstance(traj_df, pd.DataFrame)
-    assert "iteration" in traj_df.columns
-    assert "objective_total_trajectory" in traj_df.columns
-    assert "objective_error_trajectory" in traj_df.columns
-    assert "loss_trajectory" in traj_df.columns
     assert len(traj_df) > 0
+
+    # Original columns still present
+    for col in [
+        "iteration",
+        "objective_total_trajectory",
+        "objective_error_trajectory",
+        "loss_trajectory",
+    ]:
+        assert col in traj_df.columns
+
+    # New per-variant normalized loss
+    assert "loss_per_variant_trajectory" in traj_df.columns
+
+    # Block-level diagnostics for all 4 blocks
+    for block in ["calibration", "beta0", "beta_nonbundle", "beta_bundle"]:
+        for suffix in ["error", "stepsize", "iter_num"]:
+            assert f"{block}_{suffix}" in traj_df.columns
+
+    # Per-condition columns
+    conditions = simple_data.conditions
+    for cond in conditions:
+        assert f"alpha_{cond}" in traj_df.columns
+        assert f"theta_{cond}" in traj_df.columns
+        assert f"beta0_{cond}" in traj_df.columns
+    # Sparsity only for non-reference conditions
+    ref = simple_data.reference
+    for cond in conditions:
+        if cond != ref:
+            assert f"sparsity_{cond}" in traj_df.columns
+    assert f"sparsity_{ref}" not in traj_df.columns
+
+
+def test_convergence_trajectory_block_values(fitted_simple_model):
+    """Test that block-level diagnostic values are reasonable."""
+    traj_df = fitted_simple_model.convergence_trajectory_df
+    for block in ["calibration", "beta0", "beta_nonbundle", "beta_bundle"]:
+        assert (traj_df[f"{block}_error"] >= 0).all()
+        assert (traj_df[f"{block}_stepsize"] > 0).all()
+        assert (traj_df[f"{block}_iter_num"] >= 0).all()
+
+
+def test_convergence_trajectory_per_variant_loss(fitted_simple_model):
+    """Test that loss_per_variant_trajectory is correctly normalized."""
+    traj_df = fitted_simple_model.convergence_trajectory_df
+    # The ratio loss / loss_per_variant should be constant (= n_variants_total)
+    ratios = traj_df["loss_trajectory"] / traj_df["loss_per_variant_trajectory"]
+    np.testing.assert_allclose(ratios, ratios.iloc[0])
+    # n_variants_total must be a positive integer
+    n_variants = ratios.iloc[0]
+    assert n_variants > 0
+    assert n_variants == int(n_variants)
+
+
+def test_convergence_trajectory_single_condition(fitted_single_condition_model):
+    """Test trajectory columns for single-condition model (no sparsity)."""
+    traj_df = fitted_single_condition_model.convergence_trajectory_df
+    assert len(traj_df) > 0
+    # Should have alpha/theta/beta0 for the single condition
+    assert "alpha_a" in traj_df.columns
+    assert "theta_a" in traj_df.columns
+    assert "beta0_a" in traj_df.columns
+    # No sparsity columns (reference is the only condition)
+    sparsity_cols = [c for c in traj_df.columns if c.startswith("sparsity_")]
+    assert len(sparsity_cols) == 0
 
 
 # ==================== get_mutations_df Tests ====================


### PR DESCRIPTION
## Summary

- Extends `convergence_trajectory_df` to capture all per-block optimization diagnostics (error, stepsize, inner iterations), per-condition parameter snapshots (α, θ, β0, sparsity), and a per-variant normalized loss
- Data was previously only printed in verbose mode and discarded — now always recorded with negligible overhead
- No API changes: existing columns unchanged, new columns added to the same DataFrame

Closes #209

## Test plan

- [x] All 156 existing tests pass (including doctests)
- [x] New tests verify column presence, value ranges, per-variant normalization, and single-condition edge case
- [x] ruff + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)