### PR TITLE
Improve spike data prep: post_count threshold, nonsense truncation, log2 scores

### DIFF
--- a/experiments/scv2-spike/config/config.yaml
+++ b/experiments/scv2-spike/config/config.yaml
@@ -17,9 +17,9 @@ spike:
 
   # Filtering thresholds
   pre_count_threshold: 100
-  post_count_threshold: 1
+  post_count_threshold: 0
   max_subs: 10
-  func_score_clip: [-3.5, 2.5]
+  func_score_clip: [-5.0, 3.6]
   pseudocount: 0.5
   do_truncate_nonsense: true
   subsample_frac: null  # null = use all data

--- a/experiments/scv2-spike/config/config.yaml
+++ b/experiments/scv2-spike/config/config.yaml
@@ -19,7 +19,7 @@ spike:
   pre_count_threshold: 100
   post_count_threshold: 0
   max_subs: 10
-  func_score_clip: [-5.0, 3.6]
+  func_score_clip: [-3.5, 2.5]
   pseudocount: 0.5
   do_truncate_nonsense: true
   subsample_frac: null  # null = use all data

--- a/experiments/scv2-spike/config/config_test.yaml
+++ b/experiments/scv2-spike/config/config_test.yaml
@@ -18,7 +18,7 @@ spike:
   pre_count_threshold: 100
   post_count_threshold: 0
   max_subs: 10
-  func_score_clip: [-5.0, 3.6]
+  func_score_clip: [-3.5, 2.5]
   pseudocount: 0.5
   do_truncate_nonsense: true
   subsample_frac: 0.1  # 10% subsample for fast testing

--- a/experiments/scv2-spike/config/config_test.yaml
+++ b/experiments/scv2-spike/config/config_test.yaml
@@ -16,9 +16,9 @@ spike:
 
   # Filtering thresholds
   pre_count_threshold: 100
-  post_count_threshold: 1
+  post_count_threshold: 0
   max_subs: 10
-  func_score_clip: [-3.5, 2.5]
+  func_score_clip: [-5.0, 3.6]
   pseudocount: 0.5
   do_truncate_nonsense: true
   subsample_frac: 0.1  # 10% subsample for fast testing

--- a/experiments/scv2-spike/notebooks/evaluate.ipynb
+++ b/experiments/scv2-spike/notebooks/evaluate.ipynb
@@ -35,16 +35,14 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "config_path = \"config/config.yaml\""
-   ]
+   "source": "config_path = \"config/config.yaml\"\noutput_dir = None"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "config = load_config(config_path)\nspike = config[\"spike\"]\nfit_config = spike[\"fitting\"]\nlasso_choice = spike[\"lasso_choice\"]\ncondition_titles = spike[\"condition_titles\"]\ncondition_colors = spike[\"condition_colors\"]\nexperiment_conditions = spike[\"experiment_conditions\"]\n\noutput_dir = spike.get(\"output_dir\", \"results\")"
+   "source": "config = load_config(config_path)\nspike = config[\"spike\"]\nfit_config = spike[\"fitting\"]\nlasso_choice = spike[\"lasso_choice\"]\ncondition_titles = spike[\"condition_titles\"]\ncondition_colors = spike[\"condition_colors\"]\nexperiment_conditions = spike[\"experiment_conditions\"]\n\nif output_dir is None:\n    output_dir = spike.get(\"output_dir\", \"results\")"
   },
   {
    "cell_type": "markdown",

--- a/experiments/scv2-spike/notebooks/prepare_data.ipynb
+++ b/experiments/scv2-spike/notebooks/prepare_data.ipynb
@@ -208,7 +208,7 @@
     "Sum pre-selection and post-selection counts for identical variants\n",
     "(same condition, replicate, and amino acid substitutions). This is the\n",
     "improved count-aggregation approach from the jaxmodels empirical fits\n",
-    "notebook \u2014 statistically more principled than averaging pre-computed\n",
+    "notebook — statistically more principled than averaging pre-computed\n",
     "functional scores."
    ]
   },
@@ -343,92 +343,26 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Premature-stop truncation\n",
-    "\n",
-    "For variants containing stop codons, truncate mutations to include only\n",
-    "those up to and including the first stop. Then re-aggregate counts for\n",
-    "newly identical variants, and filter to retain only pure stop-codon\n",
-    "variants (single mutation = stop) or all-missense variants."
-   ]
+   "source": "## Premature-stop truncation (stops + upstream missense retained)\n\nFor variants containing stop codons, truncate mutations to include only\nthose up to and including the first stop. Then re-aggregate counts for\nnewly identical variants. Truncated variants that retain upstream missense\nmutations (e.g. `A100G D200*`) are kept — the missense effect on selection\nis real since it occurred before the stop."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "nonsense_mask = df[\"aa_substitutions\"].str.contains(\"*\", regex=False)\n",
-    "\n",
-    "fig, axes = plt.subplots(1, 2, figsize=(8, 3))\n",
-    "sns.countplot(\n",
-    "    data=df.loc[nonsense_mask], x=\"n_subs\",\n",
-    "    ax=axes[0], color=\"steelblue\",\n",
-    ")\n",
-    "axes[0].set_title(\"Nonsense variants: before truncation\")\n",
-    "axes[0].set_xlabel(\"Number of substitutions\")\n",
-    "axes[0].set_ylabel(\"Count\")\n",
-    "axes[0].spines[[\"top\", \"right\"]].set_visible(False)\n",
-    "\n",
-    "if do_truncate_nonsense:\n",
-    "    n_before = len(df)\n",
-    "    df = df.apply(truncate_nonsense, axis=1)\n",
-    "\n",
-    "    # Re-aggregate identical variants after truncation\n",
-    "    df = (\n",
-    "        df.groupby([\"condition\", \"replicate\", \"aa_substitutions\"], dropna=False)\n",
-    "        .agg({\"n_subs\": \"first\", \"pre_count\": \"sum\", \"post_count\": \"sum\"})\n",
-    "        .reset_index()\n",
-    "    )\n",
-    "\n",
-    "    # Filter: keep only pure stop variants (n_subs == 1) or all-missense\n",
-    "    mixed_mask = (\n",
-    "        df[\"aa_substitutions\"].str.contains(\"*\", regex=False) & (df[\"n_subs\"] > 1)\n",
-    "    )\n",
-    "    df = df.loc[~mixed_mask].copy()\n",
-    "    print(\n",
-    "        f\"Nonsense truncation: {n_before} \\u2192 {len(df)} variants \"\n",
-    "        f\"({n_before - len(df)} removed/merged)\"\n",
-    "    )\n",
-    "\n",
-    "    nonsense_mask_after = df[\"aa_substitutions\"].str.contains(\"*\", regex=False)\n",
-    "    sns.countplot(\n",
-    "        data=df.loc[nonsense_mask_after], x=\"n_subs\",\n",
-    "        ax=axes[1], color=\"coral\",\n",
-    "    )\n",
-    "    axes[1].set_title(\"After truncation (pure stops only)\")\n",
-    "else:\n",
-    "    axes[1].set_title(\"Truncation disabled\")\n",
-    "\n",
-    "axes[1].set_xlabel(\"Number of substitutions\")\n",
-    "axes[1].set_ylabel(\"Count\")\n",
-    "axes[1].spines[[\"top\", \"right\"]].set_visible(False)\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
-   ]
+   "source": "nonsense_mask = df[\"aa_substitutions\"].str.contains(\"*\", regex=False)\n\nfig, axes = plt.subplots(1, 2, figsize=(8, 3))\nsns.countplot(\n    data=df.loc[nonsense_mask], x=\"n_subs\",\n    ax=axes[0], color=\"steelblue\",\n)\naxes[0].set_title(\"Nonsense variants: before truncation\")\naxes[0].set_xlabel(\"Number of substitutions\")\naxes[0].set_ylabel(\"Count\")\naxes[0].spines[[\"top\", \"right\"]].set_visible(False)\n\nif do_truncate_nonsense:\n    n_before = len(df)\n    df = df.apply(truncate_nonsense, axis=1)\n\n    # Re-aggregate identical variants after truncation\n    df = (\n        df.groupby([\"condition\", \"replicate\", \"aa_substitutions\"], dropna=False)\n        .agg({\"n_subs\": \"first\", \"pre_count\": \"sum\", \"post_count\": \"sum\"})\n        .reset_index()\n    )\n\n    print(\n        f\"Nonsense truncation: {n_before} → {len(df)} variants \"\n        f\"({n_before - len(df)} removed/merged)\"\n    )\n\n    nonsense_mask_after = df[\"aa_substitutions\"].str.contains(\"*\", regex=False)\n    sns.countplot(\n        data=df.loc[nonsense_mask_after], x=\"n_subs\",\n        ax=axes[1], color=\"coral\",\n    )\n    axes[1].set_title(\"After truncation (stops + upstream missense)\")\nelse:\n    axes[1].set_title(\"Truncation disabled\")\n\naxes[1].set_xlabel(\"Number of substitutions\")\naxes[1].set_ylabel(\"Count\")\naxes[1].spines[[\"top\", \"right\"]].set_visible(False)\nplt.tight_layout()\nplt.show()"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Compute functional scores\n",
-    "\n",
-    "Functional scores are log-ratios of aggregated counts:\n",
-    "$$f = \\log(\\text{post\\_count} + \\epsilon) - \\log(\\text{pre\\_count} + \\epsilon)$$\n",
-    "where $\\epsilon$ is the pseudocount."
-   ]
+   "source": "## Compute functional scores\n\nFunctional scores are log2-ratios of aggregated counts:\n$$f = \\log_2(\\text{post\\_count} + \\epsilon) - \\log_2(\\text{pre\\_count} + \\epsilon)$$\nwhere $\\epsilon$ is the pseudocount. Using log2 aligns with `dms-vep-pipeline-3`."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "df[\"func_score\"] = (\n",
-    "    np.log(df[\"post_count\"] + pseudocount) - np.log(df[\"pre_count\"] + pseudocount)\n",
-    ")\n",
-    "print(f\"Raw func_score range: [{df['func_score'].min():.3f}, {df['func_score'].max():.3f}]\")"
-   ]
+   "source": "df[\"func_score\"] = (\n    np.log2(df[\"post_count\"] + pseudocount) - np.log2(df[\"pre_count\"] + pseudocount)\n)\nprint(f\"Raw func_score range: [{df['func_score'].min():.3f}, {df['func_score'].max():.3f}]\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Three targeted improvements to the `experiments/scv2-spike/` data preparation pipeline:

- **post_count_threshold: 1 → 0** — Retain variants with zero post-selection counts (strongly deleterious). The pseudocount (0.5) already handles these in the functional score formula.
- **Remove mixed_mask filter** — Stop discarding truncated missense+stop variants (e.g. `A100G D200*`). Upstream missense effects on selection are real; only mutations after the first stop are removed by `truncate_nonsense`, which is already correct.
- **np.log → np.log2** — Align functional score computation with `dms-vep-pipeline-3`. Since both terms use the same log base, the wildtype-subtracted scores differ only by a constant factor (1/ln2 ≈ 1.443). Clip bounds kept at `[-3.5, 2.5]`.
- **Fix evaluate notebook output_dir** — Added missing papermill `output_dir` parameter cell (pre-existing bug that surfaced with non-default output directories).

## Production results (orca01, full dataset)

| Metric | Value |
|--------|-------|
| Total variants | 303,007 |
| post_count=0 variants | 16,964 |
| Stop-containing variants | 7,289 |
| Truncated missense+stop (n_subs > 1) | 6,154 |
| Truncation invariant (stop is last sub) | True |
| func_score range (clipped) | [-3.500, 2.500] |
| Replicate corr (Delta) | r = 0.598 (n = 3,067) |
| Replicate corr (BA.1) | r = 0.891 (n = 5,775) |
| Replicate corr (BA.2) | r = 0.855 (n = 4,503) |
| Unit tests | 168/168 passed |
| CI | 6/6 checks passed |

## Files changed

- `experiments/scv2-spike/config/config.yaml` — post_count_threshold 1→0
- `experiments/scv2-spike/config/config_test.yaml` — same
- `experiments/scv2-spike/notebooks/prepare_data.ipynb` — remove mixed_mask, np.log→np.log2, update markdown
- `experiments/scv2-spike/notebooks/evaluate.ipynb` — add output_dir papermill parameter

## Test plan

- [x] `pixi run spike-test` passes end-to-end (local)
- [x] `pixi run test` — all 168 unit tests pass
- [x] `pixi run lint` — clean
- [x] Remote production pipeline on orca01 — completed successfully
- [x] CI — 6/6 checks passed (ubuntu+macos, py3.9/3.10/3.11)

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)