### PR TITLE
Report per-condition loss in convergence trajectory

### DIFF
--- a/multidms/jaxmodels.py
+++ b/multidms/jaxmodels.py
@@ -426,6 +426,10 @@ def fit(
         - ``iteration``, ``objective_total_trajectory``,
           ``objective_error_trajectory``, ``loss_trajectory``,
           ``loss_per_variant_trajectory``
+        - Per-condition loss: ``loss_{condition}`` (total Huber loss
+          for that condition) and ``loss_per_variant_{condition}``
+          (normalized by that condition's variant count). Per-condition
+          losses sum to ``loss_trajectory``.
         - Block-level diagnostics for each optimization block
           (``calibration_error``, ``calibration_stepsize``,
           ``calibration_iter_num``, ``beta0_error``, etc.)
@@ -783,7 +787,8 @@ def fit(
                         ).mean()
                     )
 
-            loss_total = float(sum(loss_fn(model, data_sets, **loss_kwargs).values()))
+            per_condition_losses = loss_fn(model, data_sets, **loss_kwargs)
+            loss_total = float(sum(per_condition_losses.values()))
 
             trajectory_rows.append(
                 {
@@ -792,6 +797,12 @@ def fit(
                     "objective_error_trajectory": float(objective_error),
                     "loss_trajectory": loss_total,
                     "loss_per_variant_trajectory": loss_total / n_variants_total,
+                    **{f"loss_{d}": float(per_condition_losses[d]) for d in data_sets},
+                    **{
+                        f"loss_per_variant_{d}": float(per_condition_losses[d])
+                        / data_sets[d].functional_scores.shape[0]
+                        for d in data_sets
+                    },
                     "calibration_error": float(state_calibration.error),
                     "calibration_stepsize": float(state_calibration.stepsize),
                     "calibration_iter_num": int(state_calibration.iter_num),
@@ -849,6 +860,8 @@ def fit(
     ]
     condition_columns = ["alpha"] if share_alpha else []
     for d in conditions:
+        condition_columns.append(f"loss_{d}")
+        condition_columns.append(f"loss_per_variant_{d}")
         if not share_alpha:
             condition_columns.append(f"alpha_{d}")
         if has_counts:

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -137,11 +137,13 @@ class Model:
             One row per iteration with columns for overall objective
             (``iteration``, ``objective_total_trajectory``,
             ``objective_error_trajectory``, ``loss_trajectory``,
-            ``loss_per_variant_trajectory``), block-level diagnostics
-            (e.g. ``calibration_error``, ``beta0_stepsize``), and
-            shared alpha (``alpha``), and per-condition parameters
-            (``beta0_{cond}``, ``sparsity_{cond}``), and
-            ``theta_{cond}`` when count data is present.
+            ``loss_per_variant_trajectory``), per-condition loss
+            (``loss_{cond}``, ``loss_per_variant_{cond}``),
+            block-level diagnostics (e.g. ``calibration_error``,
+            ``beta0_stepsize``), shared alpha (``alpha``),
+            per-condition parameters (``beta0_{cond}``,
+            ``sparsity_{cond}``), and ``theta_{cond}`` when count
+            data is present.
         """
         return self._convergence_trajectory_df
 

--- a/multidms/plot.py
+++ b/multidms/plot.py
@@ -676,9 +676,13 @@ CONVERGENCE_TRAJECTORY_GROUPS = {
 def _detect_per_condition_groups(columns):
     """Detect per-condition column groups from DataFrame columns.
 
-    Looks for columns matching ``alpha_{cond}``, ``theta_{cond}``,
-    ``beta0_{cond}``, and ``sparsity_{cond}`` patterns and groups them
-    by parameter type.
+    Looks for columns matching ``loss_{cond}``, ``loss_per_variant_{cond}``,
+    ``alpha_{cond}``, ``theta_{cond}``, ``beta0_{cond}``, and
+    ``sparsity_{cond}`` patterns and groups them by parameter type.
+
+    Prefixes are processed in decreasing length order to avoid ambiguity
+    (e.g., ``loss_per_variant_Delta`` matching both ``loss_`` and
+    ``loss_per_variant_``).
 
     Parameters
     ----------
@@ -690,22 +694,30 @@ def _detect_per_condition_groups(columns):
     dict
         Mapping from group name to list of matching column names.
     """
-    prefixes = {
-        "alpha": "alpha_",
-        "theta": "theta_",
-        "beta0_condition": "beta0_",
-        "sparsity": "sparsity_",
-    }
+    prefixes = [
+        ("loss_per_variant_per_condition", "loss_per_variant_"),
+        ("loss_per_condition", "loss_"),
+        ("alpha", "alpha_"),
+        ("theta", "theta_"),
+        ("beta0_condition", "beta0_"),
+        ("sparsity", "sparsity_"),
+    ]
     # These are the base (non-condition) columns that start with the same prefix
     base_cols = set(CONVERGENCE_TRAJECTORY_GROUPS.get("overall", []))
     for group_cols in CONVERGENCE_TRAJECTORY_GROUPS.values():
         base_cols.update(group_cols)
 
     groups = {}
-    for group_name, prefix in prefixes.items():
-        matching = [c for c in columns if c.startswith(prefix) and c not in base_cols]
+    assigned = set()
+    for group_name, prefix in sorted(prefixes, key=lambda x: -len(x[1])):
+        matching = [
+            c
+            for c in columns
+            if c.startswith(prefix) and c not in base_cols and c not in assigned
+        ]
         if matching:
             groups[group_name] = sorted(matching)
+            assigned.update(matching)
     return groups
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -284,6 +284,59 @@ def test_convergence_trajectory_single_condition(fitted_single_condition_model):
     assert len(sparsity_cols) == 0
 
 
+def test_per_condition_loss_columns_exist(fitted_simple_model, simple_data):
+    """Test that per-condition loss columns exist in trajectory."""
+    traj_df = fitted_simple_model.convergence_trajectory_df
+    for cond in simple_data.conditions:
+        assert f"loss_{cond}" in traj_df.columns
+        assert f"loss_per_variant_{cond}" in traj_df.columns
+
+
+def test_per_condition_loss_sum_all_iterations(fitted_simple_model, simple_data):
+    """Test that per-condition losses sum to total loss for every iteration."""
+    traj_df = fitted_simple_model.convergence_trajectory_df
+    conditions = simple_data.conditions
+    per_condition_sum = sum(traj_df[f"loss_{cond}"] for cond in conditions)
+    np.testing.assert_allclose(per_condition_sum, traj_df["loss_trajectory"], rtol=1e-5)
+
+
+def test_per_condition_loss_non_negative(fitted_simple_model, simple_data):
+    """Test that all per-condition loss values are non-negative."""
+    traj_df = fitted_simple_model.convergence_trajectory_df
+    for cond in simple_data.conditions:
+        assert (traj_df[f"loss_{cond}"] >= 0).all()
+        assert (traj_df[f"loss_per_variant_{cond}"] >= 0).all()
+
+
+def test_per_condition_loss_per_variant_normalization(simple_data):
+    """Test that loss_per_variant_{d} = loss_{d} / n_variants_for_d."""
+    model = multidms.Model(simple_data)
+    model.fit(maxiter=3, warmstart=False)
+    traj_df = model.convergence_trajectory_df
+
+    for cond in simple_data.conditions:
+        # Use the jax data variant count (excludes wildtype row)
+        n_variants = model._jax_data_sets[cond].functional_scores.shape[0]
+        expected = traj_df[f"loss_{cond}"] / n_variants
+        np.testing.assert_allclose(
+            traj_df[f"loss_per_variant_{cond}"], expected, rtol=1e-10
+        )
+
+
+def test_single_condition_loss_equals_total(fitted_single_condition_model):
+    """For single-condition model, per-condition loss equals total loss."""
+    traj_df = fitted_single_condition_model.convergence_trajectory_df
+    assert len(traj_df) > 0
+    np.testing.assert_allclose(
+        traj_df["loss_a"], traj_df["loss_trajectory"], rtol=1e-10
+    )
+    np.testing.assert_allclose(
+        traj_df["loss_per_variant_a"],
+        traj_df["loss_per_variant_trajectory"],
+        rtol=1e-10,
+    )
+
+
 def test_convergence_trajectory_theta_with_count_data(count_data):
     """Test that theta columns ARE tracked when count data is present."""
     model = multidms.Model(count_data, loss_type="count_loss")

--- a/tests/test_model_collection.py
+++ b/tests/test_model_collection.py
@@ -715,3 +715,112 @@ class TestVisualization:
         )
         assert isinstance(chart, (alt.Chart, alt.LayerChart))
         chart.to_dict()
+
+    def test_per_condition_loss_in_convergence_trajectory(self, collection):
+        """Test that per-condition loss columns appear in trajectory DataFrame."""
+        df = collection.convergence_trajectory_df()
+        # Should have per-condition loss columns for each condition
+        loss_cols = [
+            c
+            for c in df.columns
+            if c.startswith("loss_")
+            and c not in {"loss_trajectory", "loss_per_variant_trajectory"}
+            and not c.startswith("loss_per_variant_")
+        ]
+        assert len(loss_cols) > 0
+
+        loss_pv_cols = [
+            c
+            for c in df.columns
+            if c.startswith("loss_per_variant_") and c != "loss_per_variant_trajectory"
+        ]
+        assert len(loss_pv_cols) > 0
+
+
+# ========== _detect_per_condition_groups tests ==========
+
+
+class TestDetectPerConditionGroups:
+    """Tests for _detect_per_condition_groups with loss columns."""
+
+    def test_detects_loss_per_condition(self):
+        """Test that loss_{cond} columns are grouped as loss_per_condition."""
+        from multidms.plot import _detect_per_condition_groups
+
+        columns = [
+            "loss_trajectory",
+            "loss_per_variant_trajectory",
+            "loss_Delta",
+            "loss_Omicron",
+            "loss_per_variant_Delta",
+            "loss_per_variant_Omicron",
+            "beta0_Delta",
+            "beta0_Omicron",
+            "sparsity_Omicron",
+        ]
+        groups = _detect_per_condition_groups(columns)
+        assert "loss_per_condition" in groups
+        assert sorted(groups["loss_per_condition"]) == ["loss_Delta", "loss_Omicron"]
+
+    def test_detects_loss_per_variant_per_condition(self):
+        """Test that loss_per_variant_{cond} columns are grouped correctly."""
+        from multidms.plot import _detect_per_condition_groups
+
+        columns = [
+            "loss_trajectory",
+            "loss_per_variant_trajectory",
+            "loss_Delta",
+            "loss_Omicron",
+            "loss_per_variant_Delta",
+            "loss_per_variant_Omicron",
+            "beta0_Delta",
+        ]
+        groups = _detect_per_condition_groups(columns)
+        assert "loss_per_variant_per_condition" in groups
+        assert sorted(groups["loss_per_variant_per_condition"]) == [
+            "loss_per_variant_Delta",
+            "loss_per_variant_Omicron",
+        ]
+
+    def test_no_column_in_multiple_groups(self):
+        """Test that no column appears in more than one group."""
+        from multidms.plot import _detect_per_condition_groups
+
+        columns = [
+            "loss_trajectory",
+            "loss_per_variant_trajectory",
+            "loss_Delta",
+            "loss_Omicron",
+            "loss_per_variant_Delta",
+            "loss_per_variant_Omicron",
+            "alpha_Delta",
+            "alpha_Omicron",
+            "beta0_Delta",
+            "beta0_Omicron",
+            "sparsity_Omicron",
+        ]
+        groups = _detect_per_condition_groups(columns)
+        all_cols = []
+        for cols in groups.values():
+            all_cols.extend(cols)
+        assert len(all_cols) == len(
+            set(all_cols)
+        ), f"Duplicate columns across groups: {all_cols}"
+
+    def test_base_cols_excluded(self):
+        """Test that static base columns are not matched by prefix detection."""
+        from multidms.plot import _detect_per_condition_groups
+
+        columns = [
+            "loss_trajectory",
+            "loss_per_variant_trajectory",
+            "loss_Delta",
+        ]
+        groups = _detect_per_condition_groups(columns)
+        if "loss_per_condition" in groups:
+            assert "loss_trajectory" not in groups["loss_per_condition"]
+        if "loss_per_variant_per_condition" in groups:
+            assert (
+                "loss_per_variant_trajectory"
+                not in groups["loss_per_variant_per_condition"]
+            )


### PR DESCRIPTION
## Summary

- Unpack the per-condition loss dict already computed inside `jaxmodels.fit()` and record `loss_{condition}` and `loss_per_variant_{condition}` columns in the convergence trajectory DataFrame. Per-condition losses sum to `loss_trajectory`; per-variant normalization uses each condition's own variant count.
- Extend `_detect_per_condition_groups()` in `plot.py` to surface these as `loss_per_condition` and `loss_per_variant_per_condition` groups in the convergence diagnostics plot dropdown. Longer prefixes are matched first to avoid ambiguity (`loss_per_variant_Delta` vs `loss_Delta`).
- No new API surface — values are additional columns in the existing trajectory DataFrame.

Closes #228

## Test plan

- `test_per_condition_loss_columns_exist` — columns present for all conditions
- `test_per_condition_loss_sum_all_iterations` — per-condition losses sum to `loss_trajectory` at every iteration (within fp tolerance)
- `test_per_condition_loss_non_negative` — all values >= 0
- `test_per_condition_loss_per_variant_normalization` — `loss_per_variant_{d}` = `loss_{d}` / jax variant count
- `test_single_condition_loss_equals_total` — single-condition model: per-condition == total
- `TestDetectPerConditionGroups` (4 tests) — prefix detection, no cross-group duplicates, base columns excluded
- `test_per_condition_loss_in_convergence_trajectory` — columns appear in `ModelCollection.convergence_trajectory_df()`
- All 178 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)