### PR TITLE
Add times_seen_threshold slider to dashboard and set default=1 in evaluate notebooks

### DIFF
--- a/experiments/dashboard.py
+++ b/experiments/dashboard.py
@@ -1,4 +1,9 @@
-"""Interactive marimo dashboard for exploring ModelCollection results."""
+"""Interactive marimo dashboard for exploring ModelCollection results.
+
+Param Correlation and Replicate Scatter tabs support a ``times_seen_threshold``
+slider that filters out mutations unseen in some conditions before the
+correlation is computed.
+"""
 
 import marimo
 
@@ -174,6 +179,18 @@ def _(mo, mc):
     return (scatter_param_dropdown,)
 
 
+@app.cell
+def _(mo):
+    times_seen_threshold_slider = mo.ui.slider(
+        start=0,
+        stop=20,
+        step=1,
+        value=1,
+        label="Min times_seen (per-condition) to include",
+    )
+    return (times_seen_threshold_slider,)
+
+
 # ── D: Tab chart computations ────────────────────────────────────────────
 
 # --- Convergence ---
@@ -222,11 +239,19 @@ def _(mo, mc, mplot, ge_dataset_dropdown, ge_fusionreg_dropdown):
 
 
 @app.cell
-def _(mo, mc):
+def _(mo, mc, times_seen_threshold_slider):
     if len(mc.fit_models["dataset_name"].unique()) < 2:
         correlation_chart = mo.md("Need at least 2 datasets for correlation analysis.")
     else:
-        correlation_chart = mc.mut_param_dataset_correlation()
+        try:
+            correlation_chart = mc.mut_param_dataset_correlation(
+                times_seen_threshold=times_seen_threshold_slider.value,
+            )
+        except Exception as _e:
+            correlation_chart = mo.md(
+                f"Correlation failed (threshold too high?): {_e}. "
+                "Try lowering the threshold slider."
+            )
     return (correlation_chart,)
 
 
@@ -241,6 +266,7 @@ def _(
     datasets,
     scatter_fusionreg_dropdown,
     scatter_param_dropdown,
+    times_seen_threshold_slider,
 ):
     if len(datasets) < 2:
         scatter_chart = mo.md("Need at least 2 datasets for scatter comparison.")
@@ -251,6 +277,7 @@ def _(
         _muts_df = mc.split_apply_combine_muts(
             groupby=("dataset_name", "fusionreg"),
             query=f"fusionreg == {_fr}",
+            times_seen_threshold=times_seen_threshold_slider.value,
         ).reset_index()
 
         d0, d1 = datasets[0], datasets[1]  # noqa: F841 (used in query)
@@ -341,6 +368,7 @@ def _(
     correlation_chart,
     scatter_fusionreg_dropdown,
     scatter_param_dropdown,
+    times_seen_threshold_slider,
     scatter_chart,
     sparsity_chart,
     summary_table,
@@ -360,7 +388,9 @@ def _(
                 ],
                 widths=[1, 3],
             ),
-            "Param Correlation": correlation_chart,
+            "Param Correlation": mo.vstack(
+                [times_seen_threshold_slider, correlation_chart]
+            ),
             "Replicate Scatter": mo.hstack(
                 [
                     scatter_chart,
@@ -368,6 +398,7 @@ def _(
                         [
                             scatter_fusionreg_dropdown,
                             scatter_param_dropdown,
+                            times_seen_threshold_slider,
                         ]
                     ),
                 ],

--- a/experiments/scv2-spike/config/config.yaml
+++ b/experiments/scv2-spike/config/config.yaml
@@ -40,7 +40,7 @@ spike:
     tol: 1.0e-4
     fusionreg_values: [0.0, 5.0e-6, 1.0e-5, 2.0e-5, 4.0e-5, 8.0e-5, 1.6e-4, 3.2e-4, 6.4e-4]
     l2reg: 0.0
-    beta0_ridge: 1.0e-4
+    beta0_ridge: 0.0
     scale_fusion_by_n: false
     ge_type: "Sigmoid"
     warmstart: false

--- a/experiments/scv2-spike/notebooks/evaluate.ipynb
+++ b/experiments/scv2-spike/notebooks/evaluate.ipynb
@@ -128,12 +128,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "corr_chart, corr_data = model_collection.mut_param_dataset_correlation(\n",
-    "    return_data=True\n",
-    ")\n",
-    "corr_chart"
-   ]
+   "source": "corr_chart, corr_data = model_collection.mut_param_dataset_correlation(\n    return_data=True,\n    times_seen_threshold=1,\n)\ncorr_chart"
   },
   {
    "cell_type": "markdown",
@@ -166,26 +161,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "fit_dict = {}\n",
-    "for _, row in model_collection.fit_models.query(\n",
-    "    f\"fusionreg == {lasso_choice}\"\n",
-    ").iterrows():\n",
-    "    fit_dict[row.dataset_name] = row.model\n",
-    "\n",
-    "mutations_df = combine_replicate_muts(fit_dict)\n",
-    "\n",
-    "mutations_df[\"sense\"] = np.where(\n",
-    "    mutations_df[\"muts\"].str.contains(\"*\", regex=False),\n",
-    "    \"stop\",\n",
-    "    \"nonsynonymous\",\n",
-    ")\n",
-    "\n",
-    "print(f\"mutations_df: {len(mutations_df):,} mutations\")\n",
-    "print(f\"  nonsynonymous: {(mutations_df['sense'] == 'nonsynonymous').sum():,}\")\n",
-    "print(f\"  stop: {(mutations_df['sense'] == 'stop').sum():,}\")\n",
-    "mutations_df.head()"
-   ]
+   "source": "fit_dict = {}\nfor _, row in model_collection.fit_models.query(\n    f\"fusionreg == {lasso_choice}\"\n).iterrows():\n    fit_dict[row.dataset_name] = row.model\n\nmutations_df = combine_replicate_muts(fit_dict, times_seen_threshold=1)\n\nmutations_df[\"sense\"] = np.where(\n    mutations_df[\"muts\"].str.contains(\"*\", regex=False),\n    \"stop\",\n    \"nonsynonymous\",\n)\n\nprint(f\"mutations_df: {len(mutations_df):,} mutations\")\nprint(f\"  nonsynonymous: {(mutations_df['sense'] == 'nonsynonymous').sum():,}\")\nprint(f\"  stop: {(mutations_df['sense'] == 'stop').sum():,}\")\nmutations_df.head()"
   },
   {
    "cell_type": "markdown",
@@ -199,24 +175,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "groupby = (\"dataset_name\", \"fusionreg\")\n",
-    "collection_muts_df = model_collection.split_apply_combine_muts(\n",
-    "    groupby=groupby\n",
-    ")\n",
-    "\n",
-    "mutations_df.to_csv(os.path.join(output_dir, \"mutations_df.csv\"), index=False)\n",
-    "print(f\"Saved mutations_df.csv ({len(mutations_df):,} rows)\")\n",
-    "\n",
-    "collection_muts_df.to_csv(os.path.join(output_dir, \"collection_muts.csv\"), index=False)\n",
-    "print(f\"Saved collection_muts.csv ({len(collection_muts_df):,} rows)\")\n",
-    "\n",
-    "sparsity_data.to_csv(os.path.join(output_dir, \"fit_sparsity.csv\"), index=False)\n",
-    "print(f\"Saved fit_sparsity.csv ({len(sparsity_data)} rows)\")\n",
-    "\n",
-    "corr_data.to_csv(os.path.join(output_dir, \"library_replicate_correlation.csv\"), index=False)\n",
-    "print(f\"Saved library_replicate_correlation.csv ({len(corr_data)} rows)\")"
-   ]
+   "source": "groupby = (\"dataset_name\", \"fusionreg\")\ncollection_muts_df = model_collection.split_apply_combine_muts(\n    groupby=groupby,\n    times_seen_threshold=1,\n)\n\nmutations_df.to_csv(os.path.join(output_dir, \"mutations_df.csv\"), index=False)\nprint(f\"Saved mutations_df.csv ({len(mutations_df):,} rows)\")\n\ncollection_muts_df.to_csv(os.path.join(output_dir, \"collection_muts.csv\"), index=False)\nprint(f\"Saved collection_muts.csv ({len(collection_muts_df):,} rows)\")\n\nsparsity_data.to_csv(os.path.join(output_dir, \"fit_sparsity.csv\"), index=False)\nprint(f\"Saved fit_sparsity.csv ({len(sparsity_data)} rows)\")\n\ncorr_data.to_csv(os.path.join(output_dir, \"library_replicate_correlation.csv\"), index=False)\nprint(f\"Saved library_replicate_correlation.csv ({len(corr_data)} rows)\")"
   }
  ],
  "metadata": {

--- a/experiments/simulation/notebooks/evaluate.ipynb
+++ b/experiments/simulation/notebooks/evaluate.ipynb
@@ -12,12 +12,12 @@
     "and variant phenotype predictions.\n",
     "\n",
     "**Outline**\n",
-    "1. Convergence diagnostics \u2014 check converged status, plot loss trajectories\n",
-    "2. Mutation effect accuracy \u2014 beta and shift vs ground truth, save `model_vs_truth_beta_shift.csv`\n",
-    "3. Shift sparsity \u2014 fraction of shifts exactly zero, save `fit_sparsity.csv`\n",
-    "4. Replicate correlations \u2014 lib_1 vs lib_2 mutation parameters, save `library_replicate_correlation.csv`\n",
-    "5. Variant phenotype predictions \u2014 predicted vs true variant phenotypes, save `model_vs_truth_variant_phenotype.csv`\n",
-    "6. Additional visualizations \u2014 latent vs functional score, pairplot, violin by variant class, phenotype vs lambda\n"
+    "1. Convergence diagnostics — check converged status, plot loss trajectories\n",
+    "2. Mutation effect accuracy — beta and shift vs ground truth, save `model_vs_truth_beta_shift.csv`\n",
+    "3. Shift sparsity — fraction of shifts exactly zero, save `fit_sparsity.csv`\n",
+    "4. Replicate correlations — lib_1 vs lib_2 mutation parameters, save `library_replicate_correlation.csv`\n",
+    "5. Variant phenotype predictions — predicted vs true variant phenotypes, save `model_vs_truth_variant_phenotype.csv`\n",
+    "6. Additional visualizations — latent vs functional score, pairplot, violin by variant class, phenotype vs lambda\n"
    ]
   },
   {
@@ -154,31 +154,7 @@
    "id": "11",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "model_collection = ModelCollection(fit_collection_df)\n",
-    "\n",
-    "groupby = (\"library\", \"measurement_type\", \"fusionreg\")\n",
-    "collection_muts_df = (\n",
-    "    model_collection.split_apply_combine_muts(groupby=groupby)\n",
-    "    .reset_index()\n",
-    "    .rename(\n",
-    "        {\"beta_h1\": \"predicted_beta\", \"shift_h2\": \"predicted_shift_h2\"},\n",
-    "        axis=1,\n",
-    "    )\n",
-    "    .merge(\n",
-    "        mut_effects_df.rename(\n",
-    "            {\n",
-    "                \"beta_h1\": \"true_beta\",\n",
-    "                \"beta_h2\": \"true_beta_h2\",\n",
-    "                \"shift\": \"true_shift\",\n",
-    "            },\n",
-    "            axis=1,\n",
-    "        ),\n",
-    "        on=\"mutation\",\n",
-    "    )\n",
-    ")\n",
-    "print(f\"collection_muts_df: {collection_muts_df.shape[0]} rows\")"
-   ]
+   "source": "model_collection = ModelCollection(fit_collection_df)\n\ngroupby = (\"library\", \"measurement_type\", \"fusionreg\")\ncollection_muts_df = (\n    model_collection.split_apply_combine_muts(groupby=groupby, times_seen_threshold=1)\n    .reset_index()\n    .rename(\n        {\"beta_h1\": \"predicted_beta\", \"shift_h2\": \"predicted_shift_h2\"},\n        axis=1,\n    )\n    .merge(\n        mut_effects_df.rename(\n            {\n                \"beta_h1\": \"true_beta\",\n                \"beta_h2\": \"true_beta_h2\",\n                \"shift\": \"true_shift\",\n            },\n            axis=1,\n        ),\n        on=\"mutation\",\n    )\n)\nprint(f\"collection_muts_df: {collection_muts_df.shape[0]} rows\")"
   },
   {
    "cell_type": "code",
@@ -269,7 +245,7 @@
    "id": "17",
    "metadata": {},
    "outputs": [],
-   "source": "_, corr_data = model_collection.mut_param_dataset_correlation(\n    return_data=True\n)\n\ncorr_data = (\n    corr_data.assign(\n        lib1=corr_data.datasets.str.split(\",\").str[0],\n        lib2=corr_data.datasets.str.split(\",\").str[1],\n        measurement_type_1=lambda x: (\n            x[\"lib1\"].str.split(\"_\").str[2:4].str.join(\"_\")\n        ),\n        measurement_type_2=lambda x: (\n            x[\"lib2\"].str.split(\"_\").str[2:4].str.join(\"_\")\n        ),\n    )\n    .query(\n        \"(measurement_type_1 == measurement_type_2) \"\n        \"& (~mut_param.str.contains('predicted_func_score'))\"\n    )\n    .rename({\"measurement_type_1\": \"measurement_type\"}, axis=1)\n    .replace({\"shift_h2\": \"shift\"})\n    .drop([\"lib1\", \"lib2\", \"datasets\", \"measurement_type_2\"], axis=1)\n)\n\ncorr_data[\"measurement_type\"] = pd.Categorical(\n    corr_data[\"measurement_type\"],\n    categories=[\"observed_phenotype\", \"loose_bottle\", \"tight_bottle\"],\n    ordered=True,\n)\ncorr_data[\"mut_param\"] = pd.Categorical(\n    corr_data[\"mut_param\"],\n    categories=[\"shift\", \"beta\"],\n    ordered=True,\n)\ncorr_data[\"fusionreg_cat\"] = corr_data[\"fusionreg\"].astype(str)\n\nfor parameter, parameter_df in corr_data.groupby(\n    \"mut_param\", observed=True\n):\n    mt_vals = [\n        mt for mt in MT_ORDER\n        if mt in parameter_df[\"measurement_type\"].dropna().values\n    ]\n    fig, axes = plt.subplots(\n        1, len(mt_vals), figsize=(6, 3.3), squeeze=False\n    )\n    for ax, mt in zip(axes[0], mt_vals):\n        sub = parameter_df[\n            parameter_df[\"measurement_type\"] == mt\n        ].sort_values(\"fusionreg\")\n        ax.plot(\n            sub[\"fusionreg_cat\"], sub[\"correlation\"], marker=\"o\", color=\"k\"\n        )\n        ax.set_title(NICE_TITLES.get(mt, mt), fontsize=9)\n        ax.set_xlabel(\"lasso penalty (\\u03bb)\")\n        ax.set_ylabel(\"pearsonr\")\n        ax.tick_params(axis=\"x\", rotation=90)\n    fig.suptitle(\n        f\"Library Replicate Correlations: {parameter}\", fontsize=11\n    )\n    fig.tight_layout()\n    plt.show()\n\ncorr_data.to_csv(\n    os.path.join(output_dir, \"library_replicate_correlation.csv\"),\n    index=False,\n)\nprint(\n    f\"Saved library_replicate_correlation.csv ({len(corr_data)} rows)\"\n)"
+   "source": "_, corr_data = model_collection.mut_param_dataset_correlation(\n    return_data=True,\n    times_seen_threshold=1,\n)\n\ncorr_data = (\n    corr_data.assign(\n        lib1=corr_data.datasets.str.split(\",\").str[0],\n        lib2=corr_data.datasets.str.split(\",\").str[1],\n        measurement_type_1=lambda x: (\n            x[\"lib1\"].str.split(\"_\").str[2:4].str.join(\"_\")\n        ),\n        measurement_type_2=lambda x: (\n            x[\"lib2\"].str.split(\"_\").str[2:4].str.join(\"_\")\n        ),\n    )\n    .query(\n        \"(measurement_type_1 == measurement_type_2) \"\n        \"& (~mut_param.str.contains('predicted_func_score'))\"\n    )\n    .rename({\"measurement_type_1\": \"measurement_type\"}, axis=1)\n    .replace({\"shift_h2\": \"shift\"})\n    .drop([\"lib1\", \"lib2\", \"datasets\", \"measurement_type_2\"], axis=1)\n)\n\ncorr_data[\"measurement_type\"] = pd.Categorical(\n    corr_data[\"measurement_type\"],\n    categories=[\"observed_phenotype\", \"loose_bottle\", \"tight_bottle\"],\n    ordered=True,\n)\ncorr_data[\"mut_param\"] = pd.Categorical(\n    corr_data[\"mut_param\"],\n    categories=[\"shift\", \"beta\"],\n    ordered=True,\n)\ncorr_data[\"fusionreg_cat\"] = corr_data[\"fusionreg\"].astype(str)\n\nfor parameter, parameter_df in corr_data.groupby(\n    \"mut_param\", observed=True\n):\n    mt_vals = [\n        mt for mt in MT_ORDER\n        if mt in parameter_df[\"measurement_type\"].dropna().values\n    ]\n    fig, axes = plt.subplots(\n        1, len(mt_vals), figsize=(6, 3.3), squeeze=False\n    )\n    for ax, mt in zip(axes[0], mt_vals):\n        sub = parameter_df[\n            parameter_df[\"measurement_type\"] == mt\n        ].sort_values(\"fusionreg\")\n        ax.plot(\n            sub[\"fusionreg_cat\"], sub[\"correlation\"], marker=\"o\", color=\"k\"\n        )\n        ax.set_title(NICE_TITLES.get(mt, mt), fontsize=9)\n        ax.set_xlabel(\"lasso penalty (\\u03bb)\")\n        ax.set_ylabel(\"pearsonr\")\n        ax.tick_params(axis=\"x\", rotation=90)\n    fig.suptitle(\n        f\"Library Replicate Correlations: {parameter}\", fontsize=11\n    )\n    fig.tight_layout()\n    plt.show()\n\ncorr_data.to_csv(\n    os.path.join(output_dir, \"library_replicate_correlation.csv\"),\n    index=False,\n)\nprint(\n    f\"Saved library_replicate_correlation.csv ({len(corr_data)} rows)\"\n)"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

- Adds a `times_seen_threshold` slider (default 1, range 0–20) to `experiments/dashboard.py`. The slider appears in both the **Param Correlation** and **Replicate Scatter** tabs and is wired into `mc.mut_param_dataset_correlation(times_seen_threshold=...)` and `mc.split_apply_combine_muts(..., times_seen_threshold=...)`.
- Sets `times_seen_threshold=1` at all three call sites in `experiments/scv2-spike/notebooks/evaluate.ipynb` (`mut_param_dataset_correlation`, `combine_replicate_muts`, `split_apply_combine_muts`).
- Sets `times_seen_threshold=1` at both call sites in `experiments/simulation/notebooks/evaluate.ipynb` (`split_apply_combine_muts`, `mut_param_dataset_correlation`).
- Sets `beta0_ridge: 0.0` in `experiments/scv2-spike/config/config.yaml` for the production run.

## Motivation

Mutations whose reference-condition `times_seen == 0` in one replicate land at exactly `β = 0` (zero-initialized, no data to drive the estimate), producing prominent horizontal/vertical stripes in replicate-scatter panels that artificially deflate correlation estimates. `threshold=1` removes these — it is the weakest filter that excludes zero-evidence mutations. Setting `threshold=0` on the slider exactly reproduces pre-change behavior.

## Backward compatibility

CSV outputs (`library_replicate_correlation.csv`, `mutations_df.csv`, `collection_muts.csv`) will have fewer rows after re-running the pipeline — the removed rows are exactly those with `min(times_seen_*) == 0`. Downstream consumers (`manuscript_figures.ipynb`) should be re-run; changing correlation values are expected and indicate the filter is working.

## Test plan

- [ ] `ruff check .` and `black --check .` pass (confirmed locally)
- [ ] Launch dashboard against a spike `fit_collection.pkl`; verify slider renders in both tabs, threshold=0 reproduces old behavior, threshold=1 eliminates β=0 stripes
- [ ] Re-run spike pipeline; verify CSV row counts drop and no errors

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)