### PR TITLE
Change `beta0_ridge` to standard ridge on β0 magnitude

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ User provides a pandas DataFrame with columns for condition, substitutions, and 
 - **Multi-condition modeling**: Conditions share a reference beta vector; non-reference conditions get shift parameters capturing condition-specific effects.
 - **Loss types**: `functional_score_loss` uses per-variant `.mean()` Huber loss so conditions contribute equally regardless of variant count. `count_loss` uses `.sum()` (total NLL). Hyperparameter values are calibrated to the `.mean()` scale. As a consequence, `ModelCollection.fit_models["total_loss_*"]` columns are already per-variant averages (one per condition, plus `"total"` averaged over conditions) — do not divide again by variant count when plotting or you will produce doubly-normalized values.
 - **GE nonlinearity**: `Identity` (linear) or `Sigmoid` (nonlinear global epistasis). Alpha is shared across all conditions to prevent per-condition sigmoid degeneracy.
+- **`beta0_ridge`**: standard ridge on β0 — sums `β0**2` across **all** conditions (reference included). Not a penalty on inter-condition differences, despite the name. See `multidms.jaxmodels._beta_ridge_penalty`.
 - **Plotting separation**: Rendering logic is fully separated from data preparation. Classes own data extraction (`get_*_df`, `_prepare_*_df`); `plot.py` owns chart construction.
 - **Interactive dashboard**: `experiments/dashboard.py` is a marimo app for exploring `ModelCollection` results interactively. Launch with `pixi run dashboard`.
 
@@ -112,6 +113,8 @@ Before launching any remote pipeline:
 7. **Clean up**: Remove local worktree, remote worktree, and tmux session
 
 Convention: `output_dir` is always `results-<profile>-<branch>` (e.g., `results-prod-fix-alpha`).
+
+**`beta_clip_range` in YAML configs**: use a single `null` (scalar) to disable clipping — not `[null, null]`, which deserializes to a 2-tuple of `None`s and crashes at `jnp.clip` argument unpacking.
 
 Never skip step 2. Never leave tmux sessions running after fetching results.
 

--- a/experiments/loss-normalization/notebooks/_common.py
+++ b/experiments/loss-normalization/notebooks/_common.py
@@ -21,6 +21,19 @@ def load_config(config_path):
     return config
 
 
+def _clip_range(value):
+    """Normalize a beta_clip_range YAML value for jaxmodels.fit.
+
+    The config value may be a 2-element list (box constraint), or null / None
+    (no clipping). jaxmodels checks ``if beta_clip_range is not None`` to enable
+    clipping, so None must propagate through unchanged; non-None must be a
+    tuple of length 2.
+    """
+    if value is None:
+        return None
+    return tuple(value)
+
+
 def build_fit_params(fit_config, datasets):
     """Build a fitting parameter dict that sweeps fusionreg AND l2reg.
 
@@ -54,6 +67,6 @@ def build_fit_params(fit_config, datasets):
         "beta0_init": [fit_config["beta0_init"]],
         "alpha_init": [fit_config["alpha_init"]],
         "share_alpha": [fit_config.get("share_alpha", True)],
-        "beta_clip_range": [tuple(fit_config["beta_clip_range"])],
+        "beta_clip_range": [_clip_range(fit_config["beta_clip_range"])],
         "dataset": datasets,
     }

--- a/experiments/scv2-spike/config/config.yaml
+++ b/experiments/scv2-spike/config/config.yaml
@@ -34,23 +34,25 @@ spike:
     Omicron_BA1: "BA.1"
     Omicron_BA2: "BA.2"
 
-  # Fitting parameters — rescaled for .mean() loss normalization (V0.4.0 anchors)
+  # Fitting parameters — beta0_ridge is a standard ridge on β0 magnitudes
+  # (see issue #237). beta_clip_range: null disables clipping; relying on
+  # smooth regularization (l2reg on β, beta0_ridge on β0) instead.
   fitting:
-    maxiter: 50
-    tol: 1.0e-4
+    maxiter: 75
+    tol: 1.0e-5
     fusionreg_values: [0.0, 5.0e-6, 1.0e-5, 2.0e-5, 4.0e-5, 8.0e-5, 1.6e-4, 3.2e-4, 6.4e-4]
-    l2reg: 0.0
-    beta0_ridge: 0.0
+    l2reg: 1.0e-7
+    beta0_ridge: 1.0e-3
     scale_fusion_by_n: false
     ge_type: "Sigmoid"
     warmstart: false
     beta0_init: {Omicron_BA1: 0.0, Delta: 0.0, Omicron_BA2: 0.0}
     alpha_init: 6.0
     share_alpha: true
-    beta_clip_range: [-10, 10]
+    beta_clip_range: null
     loss_kwargs: {"δ": 1.0}
-    ge_kwargs: {tol: 1.0e-4, maxiter: 50, maxls: 40, jit: true, verbose: false}
-    cal_kwargs: {tol: 1.0e-4, maxiter: 50, maxls: 40, jit: true, verbose: false}
+    ge_kwargs: {tol: 1.0e-5, maxiter: 75, maxls: 40, jit: true, verbose: false}
+    cal_kwargs: {tol: 1.0e-5, maxiter: 75, maxls: 40, jit: true, verbose: false}
     n_processes: null  # null = auto: min(cpu_count // 2, n_models)
   lasso_choice: 4.0e-5
 

--- a/experiments/scv2-spike/config/config_experimental.yaml
+++ b/experiments/scv2-spike/config/config_experimental.yaml
@@ -39,7 +39,7 @@ spike:
     tol: 1.0e-4
     fusionreg_values: [0.0, 1.0e-5, 4.0e-5, 1.6e-4]
     l2reg: 0.0
-    beta0_ridge: 1.0e-4
+    beta0_ridge: 0.0  # was 1.0e-4 under old difference-from-reference semantics
     scale_fusion_by_n: false
     ge_type: "Sigmoid"
     warmstart: false

--- a/experiments/scv2-spike/config/config_test.yaml
+++ b/experiments/scv2-spike/config/config_test.yaml
@@ -39,7 +39,7 @@ spike:
     tol: 1.0e-4
     fusionreg_values: [0.0, 4.0e-5]
     l2reg: 0.0
-    beta0_ridge: 1.0e-4
+    beta0_ridge: 0.0  # was 1.0e-4 under old difference-from-reference semantics
     scale_fusion_by_n: false
     ge_type: "Sigmoid"
     warmstart: false

--- a/experiments/scv2-spike/notebooks/_common.py
+++ b/experiments/scv2-spike/notebooks/_common.py
@@ -168,6 +168,19 @@ def truncate_nonsense(row):
     return row
 
 
+def _clip_range(value):
+    """Normalize a beta_clip_range YAML value for jaxmodels.fit.
+
+    The config value may be a 2-element list (box constraint), or null / None
+    (no clipping). jaxmodels checks ``if beta_clip_range is not None`` to enable
+    clipping, so None must propagate through unchanged; non-None must be a
+    tuple of length 2.
+    """
+    if value is None:
+        return None
+    return tuple(value)
+
+
 def build_fit_params(fit_config, datasets):
     """Build a standard fitting parameter dict from a config section.
 
@@ -198,7 +211,7 @@ def build_fit_params(fit_config, datasets):
         "beta0_init": [fit_config["beta0_init"]],
         "alpha_init": [fit_config["alpha_init"]],
         "share_alpha": [fit_config.get("share_alpha", True)],
-        "beta_clip_range": [tuple(fit_config["beta_clip_range"])],
+        "beta_clip_range": [_clip_range(fit_config["beta_clip_range"])],
         "dataset": datasets,
     }
 

--- a/experiments/simulation/notebooks/_common.py
+++ b/experiments/simulation/notebooks/_common.py
@@ -211,6 +211,19 @@ def all_muts_known(substitutions, known_muts):
     return all(m in known_muts for m in substitutions.split())
 
 
+def _clip_range(value):
+    """Normalize a beta_clip_range YAML value for jaxmodels.fit.
+
+    The config value may be a 2-element list (box constraint), or null / None
+    (no clipping). jaxmodels checks ``if beta_clip_range is not None`` to enable
+    clipping, so None must propagate through unchanged; non-None must be a
+    tuple of length 2.
+    """
+    if value is None:
+        return None
+    return tuple(value)
+
+
 def build_fit_params(fit_config, datasets):
     """Build a standard fitting parameter dict from a config section.
 
@@ -241,7 +254,7 @@ def build_fit_params(fit_config, datasets):
         "beta0_init": [fit_config["beta0_init"]],
         "alpha_init": [fit_config["alpha_init"]],
         "share_alpha": [fit_config.get("share_alpha", True)],
-        "beta_clip_range": [tuple(fit_config["beta_clip_range"])],
+        "beta_clip_range": [_clip_range(fit_config["beta_clip_range"])],
         "dataset": datasets,
     }
 

--- a/multidms/jaxmodels.py
+++ b/multidms/jaxmodels.py
@@ -361,6 +361,22 @@ def functional_score_loss(
     return result
 
 
+def _beta_ridge_penalty(model: Model, beta0_ridge: Float = 0.0) -> Float:
+    r"""Ridge penalty on squared β0, summed across all conditions.
+
+    Args:
+        model: Model whose β0 parameters are penalized.
+        beta0_ridge: Penalty strength.
+
+    Returns:
+        ``beta0_ridge * sum(model.φ[d].β0 ** 2 for d in model.φ)``.
+    """
+    penalty = 0.0
+    for d in model.φ:
+        penalty += model.φ[d].β0 ** 2
+    return penalty * beta0_ridge
+
+
 def fit(
     data_sets: dict[str, Data],
     reference_condition: str,
@@ -393,7 +409,8 @@ def fit(
         reference_condition: The condition to use as a reference.
         l2reg: L2 regularization strength for mutation effects.
         fusionreg: Fusion (shift lasso) regularization strength.
-        beta0_ridge: Ridge penalty for β0 differences from reference condition.
+        beta0_ridge: Ridge penalty on squared β0, summed across all conditions
+            (reference included).
         scale_fusion_by_n: If True, weight each condition's fusion penalty by
             n_ref / n_d, reducing shrinkage for data-poor conditions.
         block_iters: Number iterations for block coordinate descent.
@@ -468,15 +485,6 @@ def fit(
         for d, w in fusion_weights.items():
             n_d = data_sets[d].functional_scores.shape[0]
             print(f"  {d}: {w:.3f} (n_ref={n_ref}, n_d={n_d})")
-
-    def _beta_ridge_penalty(model: Model, beta0_ridge=0.0) -> Float:
-        r"""Calculate ridge penalty for β0 differences from reference condition."""
-        penalty = 0.0
-        ref_beta0 = model.φ[model.reference_condition].β0
-        for d in model.φ:
-            if d != model.reference_condition:
-                penalty += (model.φ[d].β0 - ref_beta0) ** 2
-        return penalty * beta0_ridge
 
     @jax.jit
     def objective_part(model_part, model_rest, data_sets, scale=1.0, beta0_ridge=0.0):

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -38,7 +38,8 @@ class Model:
     fusionreg : float
         Fusion regularization strength for shift parameters (default: 0.0).
     beta0_ridge : float
-        Ridge penalty for β0 offsets from reference condition (default: 0.0).
+        Ridge penalty on squared β0, summed across all conditions
+        (reference included; default: 0.0).
 
     Example
     -------

--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -84,7 +84,8 @@ def fit_one_model(
     fusionreg : float
         Fusion (shift lasso) regularization strength.
     beta0_ridge : float
-        Ridge penalty for beta0 differences from reference condition.
+        Ridge penalty on squared β0, summed across all conditions
+        (reference included).
     scale_fusion_by_n : bool
         Weight each condition's fusion penalty by n_ref / n_d.
     loss_type : str

--- a/tests/test_jaxmodels.py
+++ b/tests/test_jaxmodels.py
@@ -735,78 +735,114 @@ class TestFitParameters:
             assert jnp.all(jnp.isfinite(model_reg.φ[cond].β))
 
     def test_beta0_ridge_penalty(self, multi_condition_data):
-        """Test beta0_ridge penalty for constraining β0 differences from reference."""
-        # Fit model without beta0_ridge
-        model_no_ridge, _ = jaxmodels.fit(
+        """Test beta0_ridge shrinks β0 magnitudes across all conditions."""
+        kwargs = dict(
             data_sets=multi_condition_data,
             reference_condition="condition1",
             l2reg=0.1,
             fusionreg=0.0,
-            beta0_ridge=0.0,
-            block_iters=5,  # More iterations to see the effect
-            warmstart=False,
-            beta0_init={
-                "condition1": 1.0,
-                "condition2": -1.0,
-            },  # Start with different values
-        )
-
-        # Fit model with moderate beta0_ridge
-        model_moderate_ridge, _ = jaxmodels.fit(
-            data_sets=multi_condition_data,
-            reference_condition="condition1",
-            l2reg=0.1,
-            fusionreg=0.0,
-            beta0_ridge=1.0,
             block_iters=5,
             warmstart=False,
-            beta0_init={"condition1": 1.0, "condition2": -1.0},  # Same starting point
+            beta0_init={"condition1": 1.0, "condition2": -1.0},
         )
+        model_no_ridge, _ = jaxmodels.fit(**kwargs, beta0_ridge=0.0)
+        model_moderate, _ = jaxmodels.fit(**kwargs, beta0_ridge=1.0)
+        model_strong, _ = jaxmodels.fit(**kwargs, beta0_ridge=10.0)
 
-        # Fit model with strong beta0_ridge
-        model_strong_ridge, _ = jaxmodels.fit(
-            data_sets=multi_condition_data,
-            reference_condition="condition1",
-            l2reg=0.1,
-            fusionreg=0.0,
-            beta0_ridge=10.0,
-            block_iters=5,
-            warmstart=False,
-            beta0_init={"condition1": 1.0, "condition2": -1.0},  # Same starting point
-        )
+        def mags(m):
+            return {d: float(jnp.abs(m.φ[d].β0)) for d in m.φ}
 
-        # Calculate β0 differences from reference
-        ref_beta0_no_ridge = model_no_ridge.φ["condition1"].β0
-        ref_beta0_moderate = model_moderate_ridge.φ["condition1"].β0
-        ref_beta0_strong = model_strong_ridge.φ["condition1"].β0
-
-        diff_no_ridge = jnp.abs(model_no_ridge.φ["condition2"].β0 - ref_beta0_no_ridge)
-        diff_moderate = jnp.abs(
-            model_moderate_ridge.φ["condition2"].β0 - ref_beta0_moderate
-        )
-        diff_strong = jnp.abs(model_strong_ridge.φ["condition2"].β0 - ref_beta0_strong)
-
-        # With stronger beta0_ridge, the differences should be smaller
-        # Allow for some tolerance due to optimization
-        assert diff_strong <= diff_moderate + 1e-2, (
-            f"Strong ridge penalty should produce smaller β0 differences: "
-            f"strong={diff_strong}, moderate={diff_moderate}"
-        )
-        assert diff_moderate <= diff_no_ridge + 1e-2, (
-            f"Moderate ridge penalty should produce smaller β0 differences "
-            f"than no ridge: moderate={diff_moderate}, "
-            f"no_ridge={diff_no_ridge}"
-        )
-
-        # All models should converge successfully
-        assert model_no_ridge is not None
-        assert model_moderate_ridge is not None
-        assert model_strong_ridge is not None
+        m0, m1, m2 = mags(model_no_ridge), mags(model_moderate), mags(model_strong)
+        for d in m0:
+            assert m2[d] <= m1[d] + 1e-2, f"{d}: strong={m2[d]}, moderate={m1[d]}"
+            assert m1[d] <= m0[d] + 1e-2, f"{d}: moderate={m1[d]}, no_ridge={m0[d]}"
 
         # All β0 values should be finite
-        for model in [model_no_ridge, model_moderate_ridge, model_strong_ridge]:
+        for model in [model_no_ridge, model_moderate, model_strong]:
             for cond in model.φ:
                 assert jnp.isfinite(model.φ[cond].β0)
+
+    def test_beta_ridge_penalty_gradient(self):
+        """Gradient of beta0_ridge penalty equals 2 * r * β0[d] for each condition."""
+        β0_vals = {"A": 1.5, "B": -0.7, "C": 2.3}
+        n_mut = 4
+        φ = {d: jaxmodels.Latent.zeros(n_mut, β0=v) for d, v in β0_vals.items()}
+        model = jaxmodels.Model(
+            φ=φ,
+            α=jnp.array(1.0),
+            logθ={d: jnp.array(0.0) for d in β0_vals},
+            reference_condition="A",
+            global_epistasis=jaxmodels.Identity(),
+        )
+        r = 0.3
+        grads = jax.grad(jaxmodels._beta_ridge_penalty)(model, r)
+        for d, v in β0_vals.items():
+            expected = 2 * r * v
+            actual = float(grads.φ[d].β0)
+            assert jnp.isclose(
+                actual, expected, atol=1e-6
+            ), f"{d}: grad={actual}, expected={expected}"
+
+    def test_beta_ridge_penalty_label_permutation_invariance(self):
+        """Penalty is invariant under relabeling conditions."""
+        n_mut = 4
+        model1 = jaxmodels.Model(
+            φ={
+                "A": jaxmodels.Latent.zeros(n_mut, β0=1.5),
+                "B": jaxmodels.Latent.zeros(n_mut, β0=-0.7),
+            },
+            α=jnp.array(1.0),
+            logθ={"A": jnp.array(0.0), "B": jnp.array(0.0)},
+            reference_condition="A",
+            global_epistasis=jaxmodels.Identity(),
+        )
+        # Same β0 magnitudes, relabeled: reference is now the one with β0=-0.7.
+        model2 = jaxmodels.Model(
+            φ={
+                "A": jaxmodels.Latent.zeros(n_mut, β0=-0.7),
+                "B": jaxmodels.Latent.zeros(n_mut, β0=1.5),
+            },
+            α=jnp.array(1.0),
+            logθ={"A": jnp.array(0.0), "B": jnp.array(0.0)},
+            reference_condition="B",
+            global_epistasis=jaxmodels.Identity(),
+        )
+        r = 0.5
+        p1 = float(jaxmodels._beta_ridge_penalty(model1, r))
+        p2 = float(jaxmodels._beta_ridge_penalty(model2, r))
+        assert jnp.isclose(p1, p2, atol=1e-6), f"p1={p1}, p2={p2}"
+
+    def test_beta_ridge_penalty_zero_at_origin(self):
+        """Penalty is zero when every β0 is zero, and strictly positive otherwise."""
+        n_mut = 4
+        # All β0 = 0 → penalty exactly 0 for any r.
+        model_origin = jaxmodels.Model(
+            φ={
+                "A": jaxmodels.Latent.zeros(n_mut, β0=0.0),
+                "B": jaxmodels.Latent.zeros(n_mut, β0=0.0),
+                "C": jaxmodels.Latent.zeros(n_mut, β0=0.0),
+            },
+            α=jnp.array(1.0),
+            logθ={d: jnp.array(0.0) for d in ["A", "B", "C"]},
+            reference_condition="A",
+            global_epistasis=jaxmodels.Identity(),
+        )
+        assert float(jaxmodels._beta_ridge_penalty(model_origin, 10.0)) == 0.0
+
+        # Any nonzero β0 → strictly positive penalty for r > 0.
+        model_nonzero = jaxmodels.Model(
+            φ={
+                "A": jaxmodels.Latent.zeros(n_mut, β0=0.0),
+                "B": jaxmodels.Latent.zeros(n_mut, β0=0.5),
+                "C": jaxmodels.Latent.zeros(n_mut, β0=0.0),
+            },
+            α=jnp.array(1.0),
+            logθ={d: jnp.array(0.0) for d in ["A", "B", "C"]},
+            reference_condition="A",
+            global_epistasis=jaxmodels.Identity(),
+        )
+        p = float(jaxmodels._beta_ridge_penalty(model_nonzero, 10.0))
+        assert p == pytest.approx(10.0 * 0.5**2, abs=1e-10)
 
     def test_early_stopping_ignores_inner_convergence(self, multi_condition_data):
         """Test early stopping triggers on objective_error alone.


### PR DESCRIPTION
## Summary

- Rewrite `_beta_ridge_penalty` as a standard ridge: sum `β0**2` across **all** conditions (reference included) times `beta0_ridge`. The old form penalized non-reference β0 difference from the reference — asymmetric under relabeling, and left the reference unanchored.
- Extract `_beta_ridge_penalty` to a module-level function so it's unit-testable directly (was a closure inside `fit`).
- Add three new correctness tests: gradient matches `2 * r * β0[d]` for every `d`; penalty is invariant under condition relabeling; penalty is 0 iff every β0 is 0, with the formula checked against the model-under-test.
- Rewrite `test_beta0_ridge_penalty` — the old assertion (differences shrink) was literally the old invariant, so it had to change.
- Fix `tuple(fit_config["beta_clip_range"])` crash when YAML sets `beta_clip_range: null`. Shared fix across three experiment helpers (scv2-spike, simulation, loss-normalization): a `_clip_range` helper returns `None` untouched, tuple-wraps otherwise.
- Update production spike config (`config.yaml`): `tol 1e-4 → 1e-5`, `maxiter 50 → 75` (top-level + `ge_kwargs` + `cal_kwargs`); `l2reg 0 → 1e-7`; `beta0_ridge 0 → 1e-3` (new semantics); `beta_clip_range [-10, 10] → null` (disables clipping, replaced by smooth regularization on the intercept).
- Reset `beta0_ridge` in `config_experimental.yaml` and `config_test.yaml` to `0.0` — the existing `1e-4` values were calibrated for the old difference-from-reference semantics and are not directly transferable.
- Update `CLAUDE.md` with the new `beta0_ridge` semantics and the correct YAML encoding for disabling `beta_clip_range` (single `null`, not `[null, null]`).

## Test plan

- [x] `pixi run lint` — clean
- [x] `pixi run fmt-check` — clean
- [x] `pixi run test` (`pytest --doctest-modules`) — 185 passed, including 4 new correctness tests
- [x] Snakemake dry-run on updated production `config.yaml` — DAG constructs cleanly with `beta_clip_range: null`
- [x] Production scv2-spike pipeline executed on orca04 — 5/5 rules complete in ~30 min, no errors, no `TypeError` from clip handling

## Production run results

Executed `pixi run remote-pipeline -- spike prod host=orca04`. Pipeline completed cleanly; results preserved under `experiments/scv2-spike/results-prod-237-beta0-ridge-magnitude/` in the main clone (gitignored per repo convention, matching how `results-prod-232-*` and `results-prod-235-*` are handled).

Training loss at `fusionreg=0.0, rep_1` (first row of `cross_validation_loss.csv`):

| Run                                    | loss   |
|----------------------------------------|--------|
| **#237 (this PR)**                     | 0.6147 |
| #232 `l2reg-1e-7` (closest baseline)   | 0.6192 |
| #232 `tight-tol`                       | 0.5968 |
| #235 `times-seen-threshold`            | 0.6166 |

The new run lands squarely within the baseline range — a touch lower than the most directly comparable baseline (#232 `l2reg-1e-7`), consistent with tighter `tol=1e-5` and longer `maxiter=75` producing slightly better convergence. All per-condition losses finite, CV completed across the full fusionreg grid.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)