### PR TITLE
Fix IndexError in mut_param_dataset_correlation for 1-column groups

### DIFF
--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -644,6 +644,37 @@ def concat_path_trajectories(fit_collection_df, groupby_cols=None):
     return out[ordered]
 
 
+def _pairwise_correlation(replicate_params_df, r=1):
+    """Pairwise correlation between two replicates, robust to 1-column groups.
+
+    The mutation pivot used by
+    :meth:`ModelCollection.mut_param_dataset_correlation` can produce
+    1-column groups when one replicate has no surviving entry for a
+    given ``(mut_param, x)`` cell — for example under sparse shift
+    solutions. In that case the pearson correlation is undefined, so
+    we return ``NaN`` rather than letting ``iloc[0, 1]`` raise.
+
+    Parameters
+    ----------
+    replicate_params_df : pd.DataFrame
+        Rows index replicates, columns index mutations (the transposed
+        per-(mut_param, x) slice from the outer pivot).
+    r : int, optional
+        Correlation exponent: 1 for Pearson r, 2 for r-squared.
+        Default is 1.
+
+    Returns
+    -------
+    float
+        ``corr_matrix.iloc[0, 1] ** r`` when both replicates are present,
+        otherwise ``NaN``.
+    """
+    corr_mat = replicate_params_df.T.corr()
+    if corr_mat.shape[1] < 2:
+        return float("nan")
+    return corr_mat.iloc[0, 1] ** r
+
+
 class ModelCollection:
     """
     A class for the comparison and visualization of multiple
@@ -1421,7 +1452,9 @@ class ModelCollection:
                         {
                             "datasets": ",".join(datasets),
                             "mut_param": mut_param,
-                            "correlation": replicate_params_df.T.corr().iloc[0, 1] ** r,
+                            "correlation": _pairwise_correlation(
+                                replicate_params_df, r
+                            ),
                             x: x_i,
                         },
                         index=[0],

--- a/tests/test_model_collection.py
+++ b/tests/test_model_collection.py
@@ -13,6 +13,7 @@ from multidms.model_collection import (
     ModelCollectionFitError,
     _assert_no_nan,
     _extract_seed,
+    _pairwise_correlation,
     concat_path_trajectories,
     fit_models,
     fit_models_path,
@@ -650,6 +651,30 @@ class TestVisualization:
         assert isinstance(result, tuple)
         assert len(result) == 2
         assert isinstance(result[1], pd.DataFrame)
+
+    def test_pairwise_correlation_two_replicates(self):
+        """Two-replicate group returns the off-diagonal Pearson r (raised to r)."""
+        df = pd.DataFrame(
+            {
+                "rep1": [0.1, 0.2, 0.3, 0.4],
+                "rep2": [0.15, 0.18, 0.32, 0.38],
+            }
+        ).T
+        result_r1 = _pairwise_correlation(df, r=1)
+        result_r2 = _pairwise_correlation(df, r=2)
+        assert np.isclose(result_r1, df.T.corr().iloc[0, 1])
+        assert np.isclose(result_r2, df.T.corr().iloc[0, 1] ** 2)
+
+    def test_pairwise_correlation_one_replicate_returns_nan(self):
+        """1-column groups (one replicate missing) must return NaN, not raise.
+
+        Regression for the IndexError surfaced by sparse shift solutions
+        under continuation fitting, where some (mut_param, x) cells have
+        only one replicate with non-zero entries.
+        """
+        df = pd.DataFrame({"rep1": [0.1, 0.2, 0.3]}).T
+        result = _pairwise_correlation(df, r=1)
+        assert np.isnan(result)
 
     def test_mut_param_dataset_correlation(self, replicate_collection):
         import altair as alt


### PR DESCRIPTION
## Summary

Fixes a latent `IndexError` in `ModelCollection.mut_param_dataset_correlation` that surfaces when a `(mut_param, x)` group has only one replicate with a non-zero entry — a regime that's reached under sparse shift solutions (e.g. continuation-strategy fits with strong fusion regularization).

The bug was at `multidms/model_collection.py:1424`:

```python
"correlation": replicate_params_df.T.corr().iloc[0, 1] ** r,
```

When `replicate_params_df.T` has only one column, `.corr()` returns a 1×1 DataFrame and `iloc[0, 1]` raises:

```
IndexError: index 1 is out of bounds for axis 0 with size 1
```

## What changed

- Extract the per-group correlation reduction into a small helper `_pairwise_correlation(replicate_params_df, r)` that returns `NaN` for 1-column groups instead of indexing past the matrix bounds.
- Add unit tests for both branches: the 2-column happy path and the 1-column regression case.

## How this was discovered

Running the spike pipeline with `strategy: continuation`, `tol=1e-5`, `maxiter=100`, `beta0_ridge=1e-3` against the prod fusionreg grid produced sparse shift solutions where some `(mut_param, fusionreg)` cells had a single surviving replicate, tripping the latent bug. The independent-strategy run on the same hyperparameters did not hit it because its converged solutions are denser. Fit pickles from the failed run were preserved, so re-running only the `evaluate` rule reproduces the issue cheaply.

## Test plan

- [x] `pixi run fmt-check` — clean
- [x] `pixi run lint` — clean
- [x] `pixi run pytest tests/test_model_collection.py -k "pairwise_correlation or mut_param_dataset_correlation"` — 5 passed
  - `test_pairwise_correlation_two_replicates` (new)
  - `test_pairwise_correlation_one_replicate_returns_nan` (new regression test)
  - `test_mut_param_dataset_correlation` (existing, still green)
  - `test_mut_param_dataset_correlation_return_data_r1` (existing, still green)
  - `test_mut_param_dataset_correlation_return_data_r2` (existing, still green)
- [ ] CI: ruff + black + full pytest suite + docs build
- [ ] End-to-end verification: re-run spike pipeline `evaluate` rule against the cached continuation `fit_collection.pkl` and confirm it now completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)