### PR TITLE
Generalize dashboard to discover any fit_collection.pkl below cwd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ User provides a pandas DataFrame with columns for condition, substitutions, and 
 - **Loss types**: `functional_score_loss` uses per-variant `.mean()` Huber loss so conditions contribute equally regardless of variant count. `count_loss` uses `.sum()` (total NLL). Hyperparameter values are calibrated to the `.mean()` scale. As a consequence, `ModelCollection.fit_models["total_loss_*"]` columns are already per-variant averages (one per condition, plus `"total"` averaged over conditions) — do not divide again by variant count when plotting or you will produce doubly-normalized values.
 - **GE nonlinearity**: `Identity` (linear) or `Sigmoid` (nonlinear global epistasis). Alpha is shared across all conditions to prevent per-condition sigmoid degeneracy.
 - **Plotting separation**: Rendering logic is fully separated from data preparation. Classes own data extraction (`get_*_df`, `_prepare_*_df`); `plot.py` owns chart construction.
-- **Interactive dashboard**: `experiments/dashboard.py` is a marimo app for exploring `ModelCollection` results interactively. Launch with `pixi run dashboard`.
+- **Interactive dashboard**: `experiments/dashboard.py` is a marimo app for exploring `ModelCollection` results interactively. It discovers every `fit_collection.pkl` below the directory it is launched from (cwd), so it can explore any fitted collection, not just pipeline outputs. Launch with `pixi run dashboard`.
 
 ## Code Style
 

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -61,7 +61,7 @@ experiments/
 
 ## Interactive Dashboard
 
-An interactive [marimo](https://marimo.io) dashboard is available for exploring `ModelCollection` results. It auto-discovers `fit_collection.pkl` files from pipeline runs and provides tabs for convergence diagnostics, global epistasis landscape, parameter correlation, replicate scatter, and sparsity analysis.
+An interactive [marimo](https://marimo.io) dashboard is available for exploring `ModelCollection` results. It auto-discovers every `fit_collection.pkl` found below the directory it is launched from — pipeline outputs or any other fitted collection — and provides tabs for convergence diagnostics, global epistasis landscape, parameter correlation, replicate scatter, and sparsity analysis.
 
 ```bash
 # Launch the dashboard (read-only mode)

--- a/experiments/dashboard.py
+++ b/experiments/dashboard.py
@@ -1,5 +1,9 @@
 """Interactive marimo dashboard for exploring ModelCollection results.
 
+Discovers every ``fit_collection.pkl`` found below the directory the dashboard
+is launched from, so it can explore any fitted ``ModelCollection`` regardless of
+how it was produced (pipeline run or otherwise).
+
 Param Correlation and Replicate Scatter tabs support a ``times_seen_threshold``
 slider that filters out mutations unseen in some conditions before the
 correlation is computed.
@@ -47,13 +51,12 @@ def _():
 
 @app.cell
 def _():
-    import os
     import pickle
     from pathlib import Path
 
     import pandas as pd
 
-    return os, pickle, Path, pd
+    return pickle, Path, pd
 
 
 @app.cell
@@ -62,8 +65,9 @@ def _(mo):
         """
         # multidms Dashboard
 
-        Interactive exploration of `ModelCollection` results from
-        simulation and spike pipelines.
+        Interactive exploration of any `ModelCollection` result. Discovers
+        every `fit_collection.pkl` below the directory the dashboard was
+        launched from.
         """
     )
     return
@@ -82,13 +86,15 @@ def _(Path):
 
 
 @app.cell
-def _(mo, discovered_collections):
+def _(mo, Path, discovered_collections):
     if not discovered_collections:
+        _cwd = Path.cwd()
         mo.stop(
             True,
             mo.md(
-                "**No `fit_collection.pkl` found.** "
-                "Run a pipeline first (`pixi run sim-test`)."
+                f"**No `fit_collection.pkl` found** below the current "
+                f"directory (`{_cwd}`). Launch the dashboard from a directory "
+                f"that contains one, or generate one with `ModelCollection`."
             ),
         )
 

--- a/experiments/dashboard.py
+++ b/experiments/dashboard.py
@@ -7,7 +7,32 @@ correlation is computed.
 
 import marimo
 
+from pathlib import Path as _Path
+
 app = marimo.App(width="medium")
+
+
+def _discover_collections(root):
+    """Find every ``fit_collection.pkl`` below ``root``.
+
+    Args:
+        root: Directory to search recursively. Typically the directory the
+            dashboard was launched from (``Path.cwd()``).
+
+    Returns:
+        Ordered mapping of label -> absolute path, one entry per
+        ``fit_collection.pkl`` found anywhere below ``root``. The label is the
+        pkl's parent directory expressed relative to ``root`` (the filename is
+        omitted because every match shares it). Entries are sorted by path for
+        deterministic ordering. No directories are pruned: matches under
+        ``.worktrees/``, ``.pixi/``, etc. are intentionally included.
+    """
+    root = _Path(root)
+    discovered = {}
+    for p in sorted(root.rglob("fit_collection.pkl")):
+        label = str(p.parent.relative_to(root))
+        discovered[label] = p
+    return discovered
 
 
 # ── A: Setup ──────────────────────────────────────────────────────────────
@@ -48,18 +73,10 @@ def _(mo):
 
 
 @app.cell
-def _(Path, os):
-    # Resolve the experiments directory relative to this file
-    _dashboard_dir = Path(os.path.abspath(__file__)).parent
-
-    # Scan for fit_collection.pkl files
-    _pkl_paths = sorted(_dashboard_dir.glob("*/results*/fit_collection.pkl"))
-
-    # Build mapping: display label -> path
-    discovered_collections = {}
-    for p in _pkl_paths:
-        label = f"{p.parent.parent.name}/{p.parent.name}"
-        discovered_collections[label] = p
+def _(Path):
+    # Discover every fit_collection.pkl below the launch directory (cwd),
+    # labeled by parent path relative to cwd. See _discover_collections.
+    discovered_collections = _discover_collections(Path.cwd())
 
     return (discovered_collections,)
 

--- a/tests/test_dashboard_discovery.py
+++ b/tests/test_dashboard_discovery.py
@@ -6,11 +6,13 @@ from experiments.dashboard import _discover_collections
 
 
 def _touch(p: Path) -> None:
+    """Create an empty file at ``p``, making parent directories as needed."""
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_bytes(b"")
 
 
 def test_discovers_nested_pkls_labeled_by_relative_parent(tmp_path):
+    """Pkls at any depth are found and labeled by parent path relative to root."""
     _touch(tmp_path / "experiments" / "sim" / "results-test" / "fit_collection.pkl")
     _touch(tmp_path / "deep" / "a" / "b" / "run1" / "fit_collection.pkl")
 
@@ -27,6 +29,7 @@ def test_discovers_nested_pkls_labeled_by_relative_parent(tmp_path):
 
 
 def test_only_exact_filename_matches(tmp_path):
+    """Only files named exactly ``fit_collection.pkl`` are discovered."""
     _touch(tmp_path / "good" / "fit_collection.pkl")
     _touch(tmp_path / "bad" / "other.pkl")
     _touch(tmp_path / "bad" / "fit_collection.pickle")
@@ -37,6 +40,7 @@ def test_only_exact_filename_matches(tmp_path):
 
 
 def test_no_pruning_includes_dot_dirs(tmp_path):
+    """Matches under dot-directories (.worktrees, .pixi) are not pruned."""
     _touch(tmp_path / ".worktrees" / "x" / "fit_collection.pkl")
     _touch(tmp_path / ".pixi" / "y" / "fit_collection.pkl")
 
@@ -47,10 +51,12 @@ def test_no_pruning_includes_dot_dirs(tmp_path):
 
 
 def test_empty_when_none_present(tmp_path):
+    """An empty mapping is returned when no pkl exists below the root."""
     assert _discover_collections(tmp_path) == {}
 
 
 def test_results_are_sorted_by_path(tmp_path):
+    """Discovered entries are ordered deterministically by path."""
     _touch(tmp_path / "z" / "fit_collection.pkl")
     _touch(tmp_path / "a" / "fit_collection.pkl")
     _touch(tmp_path / "m" / "fit_collection.pkl")

--- a/tests/test_dashboard_discovery.py
+++ b/tests/test_dashboard_discovery.py
@@ -1,0 +1,60 @@
+"""Tests for the dashboard's fit_collection.pkl discovery helper."""
+
+from pathlib import Path
+
+from experiments.dashboard import _discover_collections
+
+
+def _touch(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"")
+
+
+def test_discovers_nested_pkls_labeled_by_relative_parent(tmp_path):
+    _touch(tmp_path / "experiments" / "sim" / "results-test" / "fit_collection.pkl")
+    _touch(tmp_path / "deep" / "a" / "b" / "run1" / "fit_collection.pkl")
+
+    found = _discover_collections(tmp_path)
+
+    assert set(found.keys()) == {
+        "experiments/sim/results-test",
+        "deep/a/b/run1",
+    }
+    for label, path in found.items():
+        assert path.is_absolute()
+        assert path.name == "fit_collection.pkl"
+        assert str(path.parent.relative_to(tmp_path)) == label
+
+
+def test_only_exact_filename_matches(tmp_path):
+    _touch(tmp_path / "good" / "fit_collection.pkl")
+    _touch(tmp_path / "bad" / "other.pkl")
+    _touch(tmp_path / "bad" / "fit_collection.pickle")
+
+    found = _discover_collections(tmp_path)
+
+    assert list(found.keys()) == ["good"]
+
+
+def test_no_pruning_includes_dot_dirs(tmp_path):
+    _touch(tmp_path / ".worktrees" / "x" / "fit_collection.pkl")
+    _touch(tmp_path / ".pixi" / "y" / "fit_collection.pkl")
+
+    found = _discover_collections(tmp_path)
+
+    assert ".worktrees/x" in found
+    assert ".pixi/y" in found
+
+
+def test_empty_when_none_present(tmp_path):
+    assert _discover_collections(tmp_path) == {}
+
+
+def test_results_are_sorted_by_path(tmp_path):
+    _touch(tmp_path / "z" / "fit_collection.pkl")
+    _touch(tmp_path / "a" / "fit_collection.pkl")
+    _touch(tmp_path / "m" / "fit_collection.pkl")
+
+    found = _discover_collections(tmp_path)
+
+    assert list(found.keys()) == ["a", "m", "z"]


### PR DESCRIPTION
Closes #248

## Summary

Generalizes the marimo dashboard so it discovers **any** `fit_collection.pkl`
below the directory it is launched from (cwd), instead of only the
pipeline-shaped `experiments/*/results*/` paths rooted at the dashboard file.
Everything downstream of loading was already generic over `ModelCollection`;
this change is confined to the discovery cell plus the descriptive strings that
still claimed the tool was pipeline-specific.

## What changed vs. the plan

- **`experiments/dashboard.py`**
  - New module-level pure helper `_discover_collections(root)` —
    `root.rglob("fit_collection.pkl")`, labeled by parent path relative to
    `root`, sorted, no pruning. Cell B is now a two-line call with
    `Path.cwd()`.
  - Empty-state message now names the launch directory and no longer mentions
    pipelines.
  - Module docstring + intro cell describe cwd-rooted discovery.
  - Dropped the now-unused `os` import.
- **`tests/test_dashboard_discovery.py`** (new) — 5 unit tests on the helper:
  nested discovery + relative-parent labels, exact-filename matching, no
  pruning of dot-dirs, empty case, deterministic sort order.
- **`experiments/README.md`** and **`CLAUDE.md`** — describe the generalized
  discovery.

## Verification

- `ruff check .` — All checks passed (whole-repo, CI-equivalent).
- `black --check experiments/dashboard.py tests/test_dashboard_discovery.py` — clean.
- `pytest tests/test_dashboard_discovery.py` — 5 passed.
- Superset check on the main clone: every old-pattern match
  (`experiments/*/results*/fit_collection.pkl`) is still found by the new
  recursive glob, which additionally surfaces `archive/` and deeper-nested
  collections — confirming the existing pipeline workflow is preserved.

## Deviations from spec

- **Test functions carry docstrings (not anticipated by the spec).** The spec's
  success criterion was "ruff passes." CI runs `ruff check .` over the whole
  repo, and `tests/` is **not** in ruff's `extend-exclude` (only `experiments/`
  is). The repo's existing test files satisfy the `D` (pydocstyle) rules, so
  the new test file's functions were given docstrings to match convention and
  keep `ruff check .` green. Note this also means `experiments/dashboard.py` is
  not linted by ruff at all (it is excluded) — only `black` formats it; the
  spec's "ruff passes on dashboard.py" was therefore satisfied trivially.
- No other deviations. The discovery semantics, labels, empty-state, and doc
  updates match the spec exactly.

Yolo trail: spec gate ✓, plan gate ✓ — full log in _ignore/yolo/248.log
