### PR TITLE
Remove dead pytest-pep8 dependency to unblock CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "pytest-pep8",
     "ruff",
     "black~=23.3.0",
     "notebook",


### PR DESCRIPTION
Closes #250

## Summary

Removes the dead `pytest-pep8` dependency from the `dev` extra. The plugin (last released 2014) registers a `pytest_collect_file(path, parent)` hook using the `path` argument that modern pytest removed, so pytest rejects it at startup — every `build-and-test` job has been failing before collecting a single test on any PR opened against current `main`.

`main`'s last green run predates the breaking `pytest` release, so its status was stale; this fix repairs CI for all PRs.

## Why removal (not pinning pytest)

- **Nothing invokes pep8** — no `--pep8` flag, no `addopts`, no marker anywhere in the repo or CI.
- **Style is already covered** by the separate `ruff check .` and `black --check` CI steps.
- Pinning pytest below the breaking version would keep an abandoned plugin alive and hold back pytest — strictly worse.

## Test plan

- `pytest tests/ --co -q` now collects **191 tests** cleanly with no `-p no:pep8` flag and no `PluginValidationError`.
- `ruff check .` passes.
- CI's fresh dependency resolve (which is where the failure actually manifested) is the definitive proof.

## Deviations from spec

None. The change is exactly the single-line deletion the spec specified.

Yolo trail: spec gate ✓, plan gate ✓ — full log in _ignore/yolo/250.log
