### PR TITLE
Dashboard: recursive pickle discovery + per-tab fit-selection tables

### DIFF
--- a/experiments/dashboard.py
+++ b/experiments/dashboard.py
@@ -1,42 +1,20 @@
 """Interactive marimo dashboard for exploring ModelCollection results.
 
-Discovers every ``fit_collection.pkl`` found below the directory the dashboard
-is launched from, so it can explore any fitted ``ModelCollection`` regardless of
-how it was produced (pipeline run or otherwise).
+Discovers every ``*.pkl`` found below the directory the dashboard is launched
+from, so it can explore any fitted ``ModelCollection`` regardless of how it was
+produced (pipeline run or otherwise). Each pickle is validated lazily when
+selected; non-collection pickles surface a friendly inline error rather than
+crashing the app.
 
-Param Correlation and Replicate Scatter tabs support a ``times_seen_threshold``
-slider that filters out mutations unseen in some conditions before the
-correlation is computed.
+Each interactive tab carries its own selectable fit table so the user can
+switch which model(s) are plotted across the full hyperparameter grid
+(fusionreg, ge_type, l2reg, scale_fusion_by_n, …). The Param Correlation and
+Replicate Scatter tabs additionally support a ``times_seen_threshold`` slider.
 """
 
 import marimo
 
-from pathlib import Path as _Path
-
 app = marimo.App(width="medium")
-
-
-def _discover_collections(root):
-    """Find every ``fit_collection.pkl`` below ``root``.
-
-    Args:
-        root: Directory to search recursively. Typically the directory the
-            dashboard was launched from (``Path.cwd()``).
-
-    Returns:
-        Ordered mapping of label -> absolute path, one entry per
-        ``fit_collection.pkl`` found anywhere below ``root``. The label is the
-        pkl's parent directory expressed relative to ``root`` (the filename is
-        omitted because every match shares it). Entries are sorted by path for
-        deterministic ordering. No directories are pruned: matches under
-        ``.worktrees/``, ``.pixi/``, etc. are intentionally included.
-    """
-    root = _Path(root)
-    discovered = {}
-    for p in sorted(root.rglob("fit_collection.pkl")):
-        label = str(p.parent.relative_to(root))
-        discovered[label] = p
-    return discovered
 
 
 # ── A: Setup ──────────────────────────────────────────────────────────────
@@ -51,12 +29,34 @@ def _():
 
 @app.cell
 def _():
-    import pickle
     from pathlib import Path
 
     import pandas as pd
 
-    return pickle, Path, pd
+    return Path, pd
+
+
+@app.cell
+def _():
+    from experiments.dashboard_helpers import (
+        common_param_columns,
+        constant_summary,
+        discover_pickles,
+        display_table_df,
+        load_collection,
+        merge_two_fits_on_mutation,
+        synthesize_isin_query,
+    )
+
+    return (
+        common_param_columns,
+        constant_summary,
+        discover_pickles,
+        display_table_df,
+        load_collection,
+        merge_two_fits_on_mutation,
+        synthesize_isin_query,
+    )
 
 
 @app.cell
@@ -66,8 +66,8 @@ def _(mo):
         # multidms Dashboard
 
         Interactive exploration of any `ModelCollection` result. Discovers
-        every `fit_collection.pkl` below the directory the dashboard was
-        launched from.
+        every `*.pkl` below the directory the dashboard was launched from;
+        each is validated when you select it.
         """
     )
     return
@@ -77,60 +77,55 @@ def _(mo):
 
 
 @app.cell
-def _(Path):
-    # Discover every fit_collection.pkl below the launch directory (cwd),
-    # labeled by parent path relative to cwd. See _discover_collections.
-    discovered_collections = _discover_collections(Path.cwd())
+def _(Path, discover_pickles, mo):
+    discovered_collections = discover_pickles(Path.cwd())
 
-    return (discovered_collections,)
-
-
-@app.cell
-def _(mo, Path, discovered_collections):
     if not discovered_collections:
         _cwd = Path.cwd()
         mo.stop(
             True,
             mo.md(
-                f"**No `fit_collection.pkl` found** below the current "
-                f"directory (`{_cwd}`). Launch the dashboard from a directory "
-                f"that contains one, or generate one with `ModelCollection`."
+                f"**No `*.pkl` found** below the current directory "
+                f"(`{_cwd}`). Launch the dashboard from a directory that "
+                f"contains a fitted `ModelCollection` pickle."
             ),
         )
 
     pipeline_dropdown = mo.ui.dropdown(
         options=list(discovered_collections.keys()),
         value=list(discovered_collections.keys())[0],
-        label="Pipeline results",
+        label="Pickle",
     )
     pipeline_dropdown
-    return (pipeline_dropdown,)
+    return discovered_collections, pipeline_dropdown
 
 
 @app.cell
-def _(mo, pickle, pipeline_dropdown, discovered_collections):
-    from multidms.model_collection import ModelCollection
-
-    mo.stop(not pipeline_dropdown.value, mo.md("Select a pipeline above."))
+def _(discovered_collections, load_collection, mo, pipeline_dropdown):
+    mo.stop(not pipeline_dropdown.value, mo.md("Select a pickle above."))
 
     _pkl_path = discovered_collections[pipeline_dropdown.value]
-    with open(_pkl_path, "rb") as _f:
-        _loaded = pickle.load(_f)
-
-    if isinstance(_loaded, ModelCollection):
-        mc = _loaded
-    else:
-        mc = ModelCollection(_loaded)
+    mc = None
+    try:
+        mc = load_collection(_pkl_path)
+    except Exception as _e:
+        mo.stop(
+            True,
+            mo.md(
+                f"**Could not load `{pipeline_dropdown.value}` as a "
+                f"`ModelCollection`.** It loaded or coerced with this error:\n\n"
+                f"```\n{_e}\n```\n\n"
+                f"Pick a different pickle above."
+            ),
+        )
 
     _n_models = len(mc.fit_models)
-    datasets = list(mc.fit_models["dataset_name"].unique())
-    fusionregs = [str(f) for f in sorted(mc.fit_models["fusionreg"].unique())]
-
+    _datasets = list(mc.fit_models["dataset_name"].unique())
     mo.md(
-        f"Loaded **{_n_models}** models from `{pipeline_dropdown.value}` "
-        f"| datasets: {datasets} | fusionreg values: {fusionregs}"
+        f"Loaded **{_n_models}** fits from `{pipeline_dropdown.value}` "
+        f"| datasets: {_datasets}"
     )
-    return mc, datasets, fusionregs
+    return (mc,)
 
 
 @app.cell
@@ -140,66 +135,38 @@ def _():
     return (mplot,)
 
 
-# ── C: Tab controls (always available) ───────────────────────────────────
+# ── C: Per-tab fit tables + sliders ──────────────────────────────────────
 
 
 @app.cell
-def _(mo, datasets, fusionregs):
-    conv_dataset_select = mo.ui.multiselect(
-        options=datasets,
-        value=datasets[:2],
-        label="Datasets",
+def _(constant_summary, display_table_df, mc, mo):
+    _const = constant_summary(mc.fit_models)
+    _caption = (
+        "constant across all fits: " + ", ".join(f"{k}={v}" for k, v in _const.items())
+        if _const
+        else "all displayed columns vary across fits"
     )
-    conv_fusionreg_select = mo.ui.multiselect(
-        options=fusionregs,
-        value=fusionregs[:1],
-        label="Fusion reg",
+
+    _table_df = display_table_df(mc.fit_models)
+
+    ge_table = mo.ui.table(_table_df, selection="single", label="GE Landscape fit")
+    conv_table = mo.ui.table(_table_df, selection="multi", label="Convergence fits")
+    sparsity_table = mo.ui.table(_table_df, selection="multi", label="Sparsity fits")
+    corr_table = mo.ui.table(
+        _table_df, selection="multi", label="Correlation fit subset"
     )
-    ge_dataset_dropdown = mo.ui.dropdown(
-        options=datasets,
-        value=datasets[0],
-        label="Dataset",
+    scatter_table = mo.ui.table(
+        _table_df, selection="multi", label="Scatter fits (pick exactly 2)"
     )
-    ge_fusionreg_dropdown = mo.ui.dropdown(
-        options=fusionregs,
-        value=fusionregs[0],
-        label="Fusion reg",
-    )
-    scatter_fusionreg_dropdown = mo.ui.dropdown(
-        options=fusionregs,
-        value=fusionregs[0],
-        label="Fusion reg",
-    )
+    table_caption = mo.md(f"*{_caption}*")
     return (
-        conv_dataset_select,
-        conv_fusionreg_select,
-        ge_dataset_dropdown,
-        ge_fusionreg_dropdown,
-        scatter_fusionreg_dropdown,
+        conv_table,
+        corr_table,
+        ge_table,
+        scatter_table,
+        sparsity_table,
+        table_caption,
     )
-
-
-# Scatter param dropdown depends on the muts columns, so we derive param
-# options from the collection's conditions.
-@app.cell
-def _(mo, mc):
-    _conditions = mc._conditions
-    _param_options = []
-    for c in _conditions:
-        _param_options.append(f"beta_{c}")
-    for c in _conditions:
-        col = f"shift_{c}"
-        # shift columns only exist for non-reference conditions
-        _param_options.append(col)
-    for c in _conditions:
-        _param_options.append(f"predicted_func_score_{c}")
-
-    scatter_param_dropdown = mo.ui.dropdown(
-        options=_param_options,
-        value=_param_options[0],
-        label="Parameter",
-    )
-    return (scatter_param_dropdown,)
 
 
 @app.cell
@@ -220,15 +187,13 @@ def _(mo):
 
 
 @app.cell
-def _(mo, mc, mplot, conv_dataset_select, conv_fusionreg_select):
-    if not conv_dataset_select.value or not conv_fusionreg_select.value:
-        convergence_chart = mo.md(
-            "Select at least one dataset and one fusionreg value."
-        )
+def _(conv_table, mc, mo, mplot, synthesize_isin_query):
+    _sel = conv_table.value  # a DataFrame of selected rows (may be empty)
+    if _sel is None or _sel.empty:
+        convergence_chart = mo.md("Select at least one fit.")
     else:
-        _ds = conv_dataset_select.value
-        _fr = [float(x) for x in conv_fusionreg_select.value]
-        _query = f"dataset_name.isin({_ds}) and fusionreg.isin({_fr})"
+        _idx = list(_sel["_fit_idx"])
+        _query = synthesize_isin_query(mc.fit_models, _idx)
         _conv_df = mc.convergence_trajectory_df(query=_query)
         convergence_chart = mplot.convergence_trajectory(
             _conv_df, id_cols=["dataset_name", "fusionreg"]
@@ -240,15 +205,12 @@ def _(mo, mc, mplot, conv_dataset_select, conv_fusionreg_select):
 
 
 @app.cell
-def _(mo, mc, mplot, ge_dataset_dropdown, ge_fusionreg_dropdown):
-    if not ge_dataset_dropdown.value or not ge_fusionreg_dropdown.value:
-        ge_chart = mo.md("Select a dataset and fusionreg.")
+def _(ge_table, mc, mo, mplot):
+    _sel = ge_table.value  # a DataFrame of selected rows (may be empty)
+    if _sel is None or len(_sel) != 1:
+        ge_chart = mo.md("Select a fit.")
     else:
-        ge_ds = ge_dataset_dropdown.value  # noqa: F841 (used in query)
-        ge_fr = float(ge_fusionreg_dropdown.value)  # noqa: F841 (used in query)
-        _row = mc.fit_models.query(
-            "dataset_name == @ge_ds and fusionreg == @ge_fr"
-        ).iloc[0]
+        _row = mc.fit_models.reset_index(drop=True).iloc[int(_sel["_fit_idx"].iloc[0])]
         _model = _row["model"]
         _variants_df, _ge_curve_df = _model.get_ge_landscape_df()
         _max_points = 5000
@@ -262,18 +224,24 @@ def _(mo, mc, mplot, ge_dataset_dropdown, ge_fusionreg_dropdown):
 
 
 @app.cell
-def _(mo, mc, times_seen_threshold_slider):
-    if len(mc.fit_models["dataset_name"].unique()) < 2:
-        correlation_chart = mo.md("Need at least 2 datasets for correlation analysis.")
+def _(corr_table, mc, mo, synthesize_isin_query, times_seen_threshold_slider):
+    _sel = corr_table.value  # a DataFrame of selected rows (may be empty)
+    _idx = list(_sel["_fit_idx"]) if _sel is not None and not _sel.empty else []
+    _src = mc.fit_models.reset_index(drop=True)
+    _n_datasets = _src.iloc[_idx]["dataset_name"].nunique() if _idx else 0
+    if _n_datasets < 2:
+        correlation_chart = mo.md("Select fits spanning ≥2 datasets.")
     else:
+        _query = synthesize_isin_query(mc.fit_models, _idx)
         try:
             correlation_chart = mc.mut_param_dataset_correlation(
+                query=_query,
                 times_seen_threshold=times_seen_threshold_slider.value,
             )
         except Exception as _e:
             correlation_chart = mo.md(
-                f"Correlation failed (threshold too high?): {_e}. "
-                "Try lowering the threshold slider."
+                f"Correlation failed: {_e}. Try lowering the threshold or "
+                "selecting different fits."
             )
     return (correlation_chart,)
 
@@ -282,46 +250,64 @@ def _(mo, mc, times_seen_threshold_slider):
 
 
 @app.cell
+def _(common_param_columns, mc, mo, scatter_table, times_seen_threshold_slider):
+    _sel = scatter_table.value  # a DataFrame of selected rows (may be empty)
+    if _sel is None or len(_sel) != 2:
+        scatter_param_dropdown = mo.ui.dropdown(options=[], label="Parameter")
+    else:
+        _src = mc.fit_models.reset_index(drop=True)
+        _ia, _ib = int(_sel["_fit_idx"].iloc[0]), int(_sel["_fit_idx"].iloc[1])
+        _muts_a = _src.iloc[_ia]["model"].get_mutations_df(
+            times_seen_threshold=times_seen_threshold_slider.value
+        )
+        _muts_b = _src.iloc[_ib]["model"].get_mutations_df(
+            times_seen_threshold=times_seen_threshold_slider.value
+        )
+        _opts = common_param_columns(_muts_a, _muts_b)
+        scatter_param_dropdown = mo.ui.dropdown(
+            options=_opts,
+            value=_opts[0] if _opts else None,
+            label="Parameter",
+        )
+    scatter_param_dropdown
+    return (scatter_param_dropdown,)
+
+
+@app.cell
 def _(
-    mo,
+    common_param_columns,
     mc,
+    merge_two_fits_on_mutation,
+    mo,
     mplot,
-    datasets,
-    scatter_fusionreg_dropdown,
     scatter_param_dropdown,
+    scatter_table,
     times_seen_threshold_slider,
 ):
-    if len(datasets) < 2:
-        scatter_chart = mo.md("Need at least 2 datasets for scatter comparison.")
+    _sel = scatter_table.value  # a DataFrame of selected rows (may be empty)
+    if _sel is None or len(_sel) != 2:
+        scatter_chart = mo.md("Select exactly 2 fits.")
+    elif scatter_param_dropdown.value is None:
+        scatter_chart = mo.md("Select a parameter to compare.")
     else:
-        _fr = float(scatter_fusionreg_dropdown.value)
-        _param_col = scatter_param_dropdown.value
-
-        _muts_df = mc.split_apply_combine_muts(
-            groupby=("dataset_name", "fusionreg"),
-            query=f"fusionreg == {_fr}",
-            times_seen_threshold=times_seen_threshold_slider.value,
-        ).reset_index()
-
-        d0, d1 = datasets[0], datasets[1]  # noqa: F841 (used in query)
-        _df0 = _muts_df.query("dataset_name == @d0")[["mutation", _param_col]]
-        _df1 = _muts_df.query("dataset_name == @d1")[["mutation", _param_col]]
-
-        _x_label = f"{_param_col} ({d0})"
-        _y_label = f"{_param_col} ({d1})"
-
-        _merged = _df0.merge(
-            _df1, on="mutation", suffixes=(f"_{d0}", f"_{d1}")
-        ).dropna()
-        _x_col = f"{_param_col}_{d0}"
-        _y_col = f"{_param_col}_{d1}"
-
+        _ia, _ib = int(_sel["_fit_idx"].iloc[0]), int(_sel["_fit_idx"].iloc[1])
+        _src = mc.fit_models.reset_index(drop=True)
+        _muts_a = _src.iloc[_ia]["model"].get_mutations_df(
+            times_seen_threshold=times_seen_threshold_slider.value
+        )
+        _muts_b = _src.iloc[_ib]["model"].get_mutations_df(
+            times_seen_threshold=times_seen_threshold_slider.value
+        )
+        _param = scatter_param_dropdown.value
+        _merged, _x_col, _y_col = merge_two_fits_on_mutation(
+            _muts_a, _muts_b, _param, key_a=_ia, key_b=_ib
+        )
         scatter_chart = mplot.replicate_param_scatter(
             _merged,
             x_col=_x_col,
             y_col=_y_col,
-            x_label=_x_label,
-            y_label=_y_label,
+            x_label=f"{_param} (fit {_ia})",
+            y_label=f"{_param} (fit {_ib})",
         )
     return (scatter_chart,)
 
@@ -330,16 +316,17 @@ def _(
 
 
 @app.cell
-def _(mo, mc):
-    _fusionregs = sorted(mc.fit_models["fusionreg"].unique())
-    if len(_fusionregs) <= 1:
-        sparsity_chart = mo.md(
-            "Sparsity plot requires multiple fusionreg values. "
-            "Only one value found in this collection."
-        )
+def _(mc, mo, sparsity_table, synthesize_isin_query):
+    _sel = sparsity_table.value  # a DataFrame of selected rows (may be empty)
+    _idx = list(_sel["_fit_idx"]) if _sel is not None and not _sel.empty else []
+    _src = mc.fit_models.reset_index(drop=True)
+    _n_fr = _src.iloc[_idx]["fusionreg"].nunique() if _idx else 0
+    if _n_fr < 2:
+        sparsity_chart = mo.md("Select fits spanning ≥2 fusionreg values.")
     else:
+        _query = synthesize_isin_query(mc.fit_models, _idx)
         try:
-            sparsity_chart = mc.shift_sparsity()
+            sparsity_chart = mc.shift_sparsity(query=_query)
         except Exception as _e:
             sparsity_chart = mo.md(f"Sparsity chart failed: {_e}")
     return (sparsity_chart,)
@@ -349,7 +336,7 @@ def _(mo, mc):
 
 
 @app.cell
-def _(mo, mc, pd):
+def _(mc, mo, pd):
     _rows = []
     for _, _fit in mc.fit_models.iterrows():
         _model = _fit["model"]
@@ -381,53 +368,43 @@ def _(mo, mc, pd):
 
 @app.cell
 def _(
-    mo,
-    conv_dataset_select,
-    conv_fusionreg_select,
+    conv_table,
     convergence_chart,
-    ge_dataset_dropdown,
-    ge_fusionreg_dropdown,
-    ge_chart,
+    corr_table,
     correlation_chart,
-    scatter_fusionreg_dropdown,
-    scatter_param_dropdown,
-    times_seen_threshold_slider,
+    ge_chart,
+    ge_table,
+    mo,
     scatter_chart,
+    scatter_param_dropdown,
+    scatter_table,
     sparsity_chart,
+    sparsity_table,
     summary_table,
+    table_caption,
+    times_seen_threshold_slider,
 ):
     mo.ui.tabs(
         {
-            "Convergence": mo.vstack(
+            "Convergence": mo.vstack([table_caption, conv_table, convergence_chart]),
+            "GE Landscape": mo.vstack([table_caption, ge_table, ge_chart]),
+            "Param Correlation": mo.vstack(
                 [
-                    mo.hstack([conv_dataset_select, conv_fusionreg_select]),
-                    convergence_chart,
+                    table_caption,
+                    corr_table,
+                    times_seen_threshold_slider,
+                    correlation_chart,
                 ]
             ),
-            "GE Landscape": mo.hstack(
+            "Replicate Scatter": mo.vstack(
                 [
-                    mo.vstack([ge_dataset_dropdown, ge_fusionreg_dropdown]),
-                    ge_chart,
-                ],
-                widths=[1, 3],
-            ),
-            "Param Correlation": mo.vstack(
-                [times_seen_threshold_slider, correlation_chart]
-            ),
-            "Replicate Scatter": mo.hstack(
-                [
+                    table_caption,
+                    scatter_table,
+                    mo.hstack([scatter_param_dropdown, times_seen_threshold_slider]),
                     scatter_chart,
-                    mo.vstack(
-                        [
-                            scatter_fusionreg_dropdown,
-                            scatter_param_dropdown,
-                            times_seen_threshold_slider,
-                        ]
-                    ),
-                ],
-                widths=[3, 1],
+                ]
             ),
-            "Sparsity": sparsity_chart,
+            "Sparsity": mo.vstack([table_caption, sparsity_table, sparsity_chart]),
             "Summary": summary_table,
         },
         lazy=True,

--- a/experiments/dashboard.py
+++ b/experiments/dashboard.py
@@ -282,7 +282,6 @@ def _(common_param_columns, mc, mo, scatter_table, times_seen_threshold_slider):
 
 @app.cell
 def _(
-    common_param_columns,
     mc,
     merge_two_fits_on_mutation,
     mo,

--- a/experiments/dashboard.py
+++ b/experiments/dashboard.py
@@ -38,7 +38,14 @@ def _():
 
 @app.cell
 def _():
-    from experiments.dashboard_helpers import (
+    # marimo always puts the notebook's own directory (``experiments/``) on
+    # ``sys.path``, so the sibling helper module is importable as a top-level
+    # module regardless of the directory the dashboard was launched from.
+    # Do NOT use ``from experiments.dashboard_helpers import ...`` — that only
+    # resolves when the repo root happens to be on the path (i.e. launched
+    # from the repo root), which breaks the core use case of launching from
+    # an arbitrary results directory below cwd.
+    from dashboard_helpers import (
         common_param_columns,
         constant_summary,
         discover_pickles,

--- a/experiments/dashboard_helpers.py
+++ b/experiments/dashboard_helpers.py
@@ -198,6 +198,28 @@ def synthesize_isin_query(fit_models, fit_indices, *, key_columns=None):
     return " and ".join(clauses)
 
 
+def _with_mutation_column(muts):
+    """Return ``muts`` with ``mutation`` as a column, not the index.
+
+    ``Model.get_mutations_df()`` returns the mutation string as the DataFrame
+    *index* (``index.name == "mutation"``), whereas some callers materialize it
+    as a column. Normalize to a column so downstream merges are agnostic to
+    which form the caller passed.
+
+    Args:
+        muts: A per-fit mutation DataFrame.
+
+    Returns:
+        A DataFrame guaranteed to have a ``mutation`` column. The input is not
+        mutated.
+    """
+    if "mutation" in muts.columns:
+        return muts
+    if muts.index.name == "mutation":
+        return muts.reset_index()
+    return muts
+
+
 def common_param_columns(muts_a, muts_b):
     """Numeric mutation-parameter columns present in both fits.
 
@@ -215,6 +237,8 @@ def common_param_columns(muts_a, muts_b):
     Returns:
         Sorted list of column names common to both and numeric in both.
     """
+    muts_a = _with_mutation_column(muts_a)
+    muts_b = _with_mutation_column(muts_b)
     num_a = {
         c
         for c in muts_a.columns
@@ -248,8 +272,8 @@ def merge_two_fits_on_mutation(muts_a, muts_b, param_col, *, key_a, key_b):
         Tuple ``(merged_df, x_col, y_col)`` with NaN rows dropped, where
         ``x_col = f"{param_col}_{key_a}"`` and ``y_col = f"{param_col}_{key_b}"``.
     """
-    left = muts_a[["mutation", param_col]]
-    right = muts_b[["mutation", param_col]]
+    left = _with_mutation_column(muts_a)[["mutation", param_col]]
+    right = _with_mutation_column(muts_b)[["mutation", param_col]]
     merged = left.merge(
         right, on="mutation", suffixes=(f"_{key_a}", f"_{key_b}")
     ).dropna()

--- a/experiments/dashboard_helpers.py
+++ b/experiments/dashboard_helpers.py
@@ -196,3 +196,61 @@ def synthesize_isin_query(fit_models, fit_indices, *, key_columns=None):
         values = list(dict.fromkeys(selected[col].tolist()))  # unique, ordered
         clauses.append(f"{col}.isin({values!r})")
     return " and ".join(clauses)
+
+
+def common_param_columns(muts_a, muts_b):
+    """Numeric mutation-parameter columns present in both fits.
+
+    Computes the intersection of the two fits' numeric columns (e.g.
+    ``beta_<cond>``, ``shift_<cond>``, ``predicted_func_score_<cond>``),
+    excluding ``mutation``. This is derived from the actual fit output rather
+    than from the private ``ModelCollection._conditions`` attribute (which
+    hand-rolls names and wrongly assumes ``shift_<cond>`` for every
+    condition).
+
+    Args:
+        muts_a: Mutation DataFrame for the first fit.
+        muts_b: Mutation DataFrame for the second fit.
+
+    Returns:
+        Sorted list of column names common to both and numeric in both.
+    """
+    num_a = {
+        c
+        for c in muts_a.columns
+        if c != "mutation" and pd.api.types.is_numeric_dtype(muts_a[c])
+    }
+    num_b = {
+        c
+        for c in muts_b.columns
+        if c != "mutation" and pd.api.types.is_numeric_dtype(muts_b[c])
+    }
+    return sorted(num_a & num_b)
+
+
+def merge_two_fits_on_mutation(muts_a, muts_b, param_col, *, key_a, key_b):
+    """Inner-merge two fits on ``mutation`` for one parameter column.
+
+    Both fits expose the parameter under the *same* column name, so the merge
+    suffixes by a fit-distinguishing key (``key_a``/``key_b``) rather than by
+    dataset name — comparing two fits of the *same* dataset at different
+    hyperparameters is an intended case, and dataset-name suffixes would
+    collide.
+
+    Args:
+        muts_a: Mutation DataFrame for the first (x-axis) fit.
+        muts_b: Mutation DataFrame for the second (y-axis) fit.
+        param_col: The shared parameter column to compare.
+        key_a: Distinguishing key for the first fit (e.g. its ``_fit_idx``).
+        key_b: Distinguishing key for the second fit.
+
+    Returns:
+        Tuple ``(merged_df, x_col, y_col)`` with NaN rows dropped, where
+        ``x_col = f"{param_col}_{key_a}"`` and ``y_col = f"{param_col}_{key_b}"``.
+    """
+    left = muts_a[["mutation", param_col]]
+    right = muts_b[["mutation", param_col]]
+    merged = left.merge(
+        right, on="mutation", suffixes=(f"_{key_a}", f"_{key_b}")
+    ).dropna()
+    return merged, f"{param_col}_{key_a}", f"{param_col}_{key_b}"

--- a/experiments/dashboard_helpers.py
+++ b/experiments/dashboard_helpers.py
@@ -157,3 +157,42 @@ def display_table_df(fit_models, *, round_to=4):
         if pd.api.types.is_float_dtype(out[c]):
             out[c] = out[c].round(round_to)
     return out
+
+
+def synthesize_isin_query(fit_models, fit_indices, *, key_columns=None):
+    """Build a pandas query string selecting the given fits by membership.
+
+    The query is built from the **un-rounded** source values in
+    ``fit_models`` (never the rounded display values), using ``.isin([...])``
+    membership so it generalizes the existing
+    ``dataset_name.isin([...]) and fusionreg.isin([...])`` idiom in the
+    dashboard. The clause for each key column lists the distinct values the
+    selected fits take on that column.
+
+    Args:
+        fit_models: A ``ModelCollection.fit_models`` DataFrame.
+        fit_indices: Positional row indices (``_fit_idx`` values) of the
+            selected fits.
+        key_columns: Columns to constrain. Defaults to ``dataset_name`` plus
+            the varying columns (excluding ``converged``, an outcome rather
+            than a selector).
+
+    Returns:
+        A pandas query string. Caller passes it to ``fit_models.query(...)``
+        or to a method that forwards ``query=`` to ``split_apply_combine``.
+    """
+    df = fit_models.reset_index(drop=True)
+    selected = df.loc[list(fit_indices)]
+    if key_columns is None:
+        key_columns = ["dataset_name"] + [
+            c for c in varying_columns(fit_models) if c != "converged"
+        ]
+        # de-dup while preserving order
+        seen = set()
+        key_columns = [c for c in key_columns if not (c in seen or seen.add(c))]
+
+    clauses = []
+    for col in key_columns:
+        values = list(dict.fromkeys(selected[col].tolist()))  # unique, ordered
+        clauses.append(f"{col}.isin({values!r})")
+    return " and ".join(clauses)

--- a/experiments/dashboard_helpers.py
+++ b/experiments/dashboard_helpers.py
@@ -1,0 +1,60 @@
+"""Pure, testable helpers for the multidms marimo dashboard.
+
+These functions hold all logic worth unit-testing (recursive pickle
+discovery, collection loading, varying-column detection, pandas-query
+synthesis from selected rows, and the two-fit merge). The marimo notebook
+``dashboard.py`` imports them inside cells so they are visible to those
+cells (marimo only exposes names a cell imports or that an ancestor cell
+returns).
+"""
+
+from pathlib import Path
+
+from multidms.model_collection import ModelCollection
+
+
+def discover_pickles(root):
+    """Find every ``*.pkl`` below ``root``.
+
+    Args:
+        root: Directory searched recursively (typically ``Path.cwd()``).
+
+    Returns:
+        Ordered mapping of ``label -> absolute Path``, one entry per
+        ``*.pkl`` found anywhere below ``root``. ``label`` is the pickle's
+        path relative to ``root`` *including the filename* (filenames now
+        differ between matches). Entries are sorted by path. No directories
+        are pruned: matches under ``.worktrees/``, ``.pixi/``, ``results/``
+        etc. are intentionally included.
+    """
+    root = Path(root)
+    discovered = {}
+    for p in sorted(root.rglob("*.pkl")):
+        label = str(p.relative_to(root))
+        discovered[label] = p
+    return discovered
+
+
+def load_collection(path):
+    """Load a pickle and coerce it to a :class:`ModelCollection`.
+
+    Args:
+        path: Filesystem path to a ``*.pkl`` file.
+
+    Returns:
+        A :class:`ModelCollection`. If the unpickled object is already a
+        ``ModelCollection`` it is returned unchanged; otherwise it is wrapped
+        via ``ModelCollection(loaded)``.
+
+    Raises:
+        Exception: Anything raised by ``pickle.load`` or the
+            ``ModelCollection`` constructor (the caller renders a friendly
+            inline error instead of crashing).
+    """
+    import pickle
+
+    with open(path, "rb") as f:
+        loaded = pickle.load(f)
+    if isinstance(loaded, ModelCollection):
+        return loaded
+    return ModelCollection(loaded)

--- a/experiments/dashboard_helpers.py
+++ b/experiments/dashboard_helpers.py
@@ -8,6 +8,7 @@ cells (marimo only exposes names a cell imports or that an ancestor cell
 returns).
 """
 
+import pickle
 from pathlib import Path
 
 import pandas as pd
@@ -17,7 +18,10 @@ from multidms.model_collection import ModelCollection
 #: Columns excluded from any fit table because ``mo.ui.table`` cannot render
 #: them (model objects, dict/object bookkeeping cells, per-row noise).
 EXCLUDED_TABLE_COLUMNS = ("model",)
-EXCLUDED_TABLE_SUFFIXES = ("_loss_training", "_init", "_kwargs")
+# ``_loss_validation`` is the sibling of ``_loss_training`` written by
+# ``ModelCollection.add_eval_loss()``; both are per-condition loss bookkeeping
+# (see ``model_collection.loss_df``) and neither belongs in the selector table.
+EXCLUDED_TABLE_SUFFIXES = ("_loss_training", "_loss_validation", "_init", "_kwargs")
 
 
 def discover_pickles(root):
@@ -58,8 +62,6 @@ def load_collection(path):
             ``ModelCollection`` constructor (the caller renders a friendly
             inline error instead of crashing).
     """
-    import pickle
-
     with open(path, "rb") as f:
         loaded = pickle.load(f)
     if isinstance(loaded, ModelCollection):
@@ -188,8 +190,7 @@ def synthesize_isin_query(fit_models, fit_indices, *, key_columns=None):
             c for c in varying_columns(fit_models) if c != "converged"
         ]
         # de-dup while preserving order
-        seen = set()
-        key_columns = [c for c in key_columns if not (c in seen or seen.add(c))]
+        key_columns = list(dict.fromkeys(key_columns))
 
     clauses = []
     for col in key_columns:

--- a/experiments/dashboard_helpers.py
+++ b/experiments/dashboard_helpers.py
@@ -10,7 +10,14 @@ returns).
 
 from pathlib import Path
 
+import pandas as pd
+
 from multidms.model_collection import ModelCollection
+
+#: Columns excluded from any fit table because ``mo.ui.table`` cannot render
+#: them (model objects, dict/object bookkeeping cells, per-row noise).
+EXCLUDED_TABLE_COLUMNS = ("model",)
+EXCLUDED_TABLE_SUFFIXES = ("_loss_training", "_init", "_kwargs")
 
 
 def discover_pickles(root):
@@ -58,3 +65,95 @@ def load_collection(path):
     if isinstance(loaded, ModelCollection):
         return loaded
     return ModelCollection(loaded)
+
+
+def selectable_columns(fit_models):
+    """Columns of ``fit_models`` eligible to appear in a fit table.
+
+    Drops the ``model`` object column and every bookkeeping column whose name
+    ends in one of :data:`EXCLUDED_TABLE_SUFFIXES`.
+
+    Args:
+        fit_models: A ``ModelCollection.fit_models`` DataFrame.
+
+    Returns:
+        List of column names, in the DataFrame's column order.
+    """
+    cols = []
+    for c in fit_models.columns:
+        if c in EXCLUDED_TABLE_COLUMNS:
+            continue
+        if any(c.endswith(suffix) for suffix in EXCLUDED_TABLE_SUFFIXES):
+            continue
+        cols.append(c)
+    return cols
+
+
+def varying_columns(fit_models):
+    """Selectable columns whose value differs across at least two fits.
+
+    Args:
+        fit_models: A ``ModelCollection.fit_models`` DataFrame.
+
+    Returns:
+        List of column names (subset of :func:`selectable_columns`) that are
+        non-constant across rows. Comparison is by stringified value so that
+        unhashable cells do not raise.
+    """
+    varying = []
+    for c in selectable_columns(fit_models):
+        if fit_models[c].astype(str).nunique(dropna=False) > 1:
+            varying.append(c)
+    return varying
+
+
+def constant_summary(fit_models):
+    """Map of selectable columns that are constant across all fits.
+
+    Args:
+        fit_models: A ``ModelCollection.fit_models`` DataFrame.
+
+    Returns:
+        Dict ``{column: the single value}`` for every selectable column whose
+        value is identical across all rows. Suitable for a caption above the
+        table.
+    """
+    summary = {}
+    for c in selectable_columns(fit_models):
+        if fit_models[c].astype(str).nunique(dropna=False) <= 1:
+            summary[c] = fit_models[c].iloc[0]
+    return summary
+
+
+def display_table_df(fit_models, *, round_to=4):
+    """Build the per-tab fit table (display only; do not query off this).
+
+    Column order: ``dataset_name``, then the varying columns, then
+    ``converged``; floats rounded to ``round_to`` decimals **for display
+    only**. The original positional row index is preserved as ``_fit_idx`` so
+    a selection can be mapped back to un-rounded source rows.
+
+    Args:
+        fit_models: A ``ModelCollection.fit_models`` DataFrame.
+        round_to: Decimal places for float display rounding.
+
+    Returns:
+        A DataFrame with one row per fit and columns
+        ``[dataset_name, *varying-minus-dataset_name-and-converged,
+        converged, _fit_idx]``.
+    """
+    varying = varying_columns(fit_models)
+    ordered = ["dataset_name"]
+    for c in varying:
+        if c not in ("dataset_name", "converged"):
+            ordered.append(c)
+    if "converged" in fit_models.columns:
+        ordered.append("converged")
+
+    df = fit_models.reset_index(drop=True).copy()
+    df["_fit_idx"] = range(len(df))
+    out = df[ordered + ["_fit_idx"]].copy()
+    for c in out.columns:
+        if pd.api.types.is_float_dtype(out[c]):
+            out[c] = out[c].round(round_to)
+    return out

--- a/tests/test_dashboard_discovery.py
+++ b/tests/test_dashboard_discovery.py
@@ -1,8 +1,8 @@
-"""Tests for the dashboard's fit_collection.pkl discovery helper."""
+"""Tests for the dashboard's recursive pickle discovery helper."""
 
 from pathlib import Path
 
-from experiments.dashboard import _discover_collections
+from experiments.dashboard_helpers import discover_pickles
 
 
 def _touch(p: Path) -> None:
@@ -11,56 +11,58 @@ def _touch(p: Path) -> None:
     p.write_bytes(b"")
 
 
-def test_discovers_nested_pkls_labeled_by_relative_parent(tmp_path):
-    """Pkls at any depth are found and labeled by parent path relative to root."""
+def test_discovers_nested_pkls_labeled_by_relative_path(tmp_path):
+    """Pkls at any depth are found, labeled by path relative to root."""
     _touch(tmp_path / "experiments" / "sim" / "results-test" / "fit_collection.pkl")
-    _touch(tmp_path / "deep" / "a" / "b" / "run1" / "fit_collection.pkl")
+    _touch(tmp_path / "deep" / "a" / "b" / "run1" / "other.pkl")
 
-    found = _discover_collections(tmp_path)
+    found = discover_pickles(tmp_path)
 
     assert set(found.keys()) == {
-        "experiments/sim/results-test",
-        "deep/a/b/run1",
+        "experiments/sim/results-test/fit_collection.pkl",
+        "deep/a/b/run1/other.pkl",
     }
     for label, path in found.items():
         assert path.is_absolute()
-        assert path.name == "fit_collection.pkl"
-        assert str(path.parent.relative_to(tmp_path)) == label
+        assert str(path.relative_to(tmp_path)) == label
 
 
-def test_only_exact_filename_matches(tmp_path):
-    """Only files named exactly ``fit_collection.pkl`` are discovered."""
+def test_matches_any_pkl_extension(tmp_path):
+    """Every ``*.pkl`` is discovered; non-pkl extensions are ignored."""
     _touch(tmp_path / "good" / "fit_collection.pkl")
-    _touch(tmp_path / "bad" / "other.pkl")
+    _touch(tmp_path / "good" / "other.pkl")
     _touch(tmp_path / "bad" / "fit_collection.pickle")
 
-    found = _discover_collections(tmp_path)
+    found = discover_pickles(tmp_path)
 
-    assert list(found.keys()) == ["good"]
+    assert set(found.keys()) == {
+        "good/fit_collection.pkl",
+        "good/other.pkl",
+    }
 
 
 def test_no_pruning_includes_dot_dirs(tmp_path):
     """Matches under dot-directories (.worktrees, .pixi) are not pruned."""
     _touch(tmp_path / ".worktrees" / "x" / "fit_collection.pkl")
-    _touch(tmp_path / ".pixi" / "y" / "fit_collection.pkl")
+    _touch(tmp_path / ".pixi" / "y" / "a.pkl")
 
-    found = _discover_collections(tmp_path)
+    found = discover_pickles(tmp_path)
 
-    assert ".worktrees/x" in found
-    assert ".pixi/y" in found
+    assert ".worktrees/x/fit_collection.pkl" in found
+    assert ".pixi/y/a.pkl" in found
 
 
 def test_empty_when_none_present(tmp_path):
     """An empty mapping is returned when no pkl exists below the root."""
-    assert _discover_collections(tmp_path) == {}
+    assert discover_pickles(tmp_path) == {}
 
 
 def test_results_are_sorted_by_path(tmp_path):
     """Discovered entries are ordered deterministically by path."""
-    _touch(tmp_path / "z" / "fit_collection.pkl")
-    _touch(tmp_path / "a" / "fit_collection.pkl")
-    _touch(tmp_path / "m" / "fit_collection.pkl")
+    _touch(tmp_path / "z" / "a.pkl")
+    _touch(tmp_path / "a" / "a.pkl")
+    _touch(tmp_path / "m" / "a.pkl")
 
-    found = _discover_collections(tmp_path)
+    found = discover_pickles(tmp_path)
 
-    assert list(found.keys()) == ["a", "m", "z"]
+    assert list(found.keys()) == ["a/a.pkl", "m/a.pkl", "z/a.pkl"]

--- a/tests/test_dashboard_discovery.py
+++ b/tests/test_dashboard_discovery.py
@@ -1,8 +1,12 @@
 """Tests for the dashboard's recursive pickle discovery helper."""
 
+import ast
 from pathlib import Path
 
 from experiments.dashboard_helpers import discover_pickles
+
+#: The marimo notebook that imports the helper module.
+_DASHBOARD_PY = Path(__file__).resolve().parents[1] / "experiments" / "dashboard.py"
 
 
 def _touch(p: Path) -> None:
@@ -66,3 +70,33 @@ def test_results_are_sorted_by_path(tmp_path):
     found = discover_pickles(tmp_path)
 
     assert list(found.keys()) == ["a/a.pkl", "m/a.pkl", "z/a.pkl"]
+
+
+def test_dashboard_imports_helper_as_top_level_module():
+    """The notebook must import the helper as a top-level module.
+
+    marimo always puts the notebook's own directory (``experiments/``) on
+    ``sys.path`` but not the repo root, so ``from dashboard_helpers import
+    ...`` resolves regardless of the directory the dashboard is launched
+    from. ``from experiments.dashboard_helpers import ...`` only resolves
+    when the repo root happens to be importable (i.e. launched from the
+    repo root) and raises ``ModuleNotFoundError: No module named
+    'experiments'`` when launched from any results directory below cwd —
+    which is the dashboard's core use case. Guard the import form so that
+    regression cannot slip back in.
+    """
+    tree = ast.parse(_DASHBOARD_PY.read_text())
+    helper_imports = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module is not None
+        and node.module.endswith("dashboard_helpers")
+    ]
+    assert helper_imports, "dashboard.py never imports dashboard_helpers"
+    for node in helper_imports:
+        assert node.module == "dashboard_helpers", (
+            f"dashboard.py imports the helper as {node.module!r}; it must be "
+            "the top-level module 'dashboard_helpers' so the marimo launch "
+            "works from any directory (see this test's docstring)."
+        )

--- a/tests/test_dashboard_helpers.py
+++ b/tests/test_dashboard_helpers.py
@@ -6,10 +6,12 @@ import pandas as pd
 import pytest
 
 from experiments.dashboard_helpers import (
+    common_param_columns,
     constant_summary,
     discover_pickles,
     display_table_df,
     load_collection,
+    merge_two_fits_on_mutation,
     selectable_columns,
     synthesize_isin_query,
     varying_columns,
@@ -161,3 +163,37 @@ def test_synthesize_query_all_rows_returns_all():
     fm = _fit_models_fixture()
     q = synthesize_isin_query(fm, [0, 1, 2])
     assert len(fm.reset_index(drop=True).query(q)) == 3
+
+
+def test_common_param_columns_intersection_numeric_only():
+    """Only numeric columns present in both fits are returned."""
+    a = pd.DataFrame(
+        {"mutation": ["M1A"], "beta_x": [1.0], "shift_y": [2.0], "label": ["z"]}
+    )
+    b = pd.DataFrame(
+        {"mutation": ["M1A"], "beta_x": [3.0], "predicted_func_score_x": [4.0]}
+    )
+    cols = common_param_columns(a, b)
+    assert cols == ["beta_x"]  # only numeric column in both, mutation excluded
+
+
+def test_merge_two_fits_suffixes_by_fit_key_not_dataset():
+    """Same-named columns are suffixed by fit key, not by dataset name."""
+    # Both fits are the SAME dataset/condition -> identical column name.
+    a = pd.DataFrame({"mutation": ["M1A", "M2B"], "beta_x": [1.0, 2.0]})
+    b = pd.DataFrame({"mutation": ["M1A", "M2B"], "beta_x": [10.0, 20.0]})
+    merged, x_col, y_col = merge_two_fits_on_mutation(a, b, "beta_x", key_a=0, key_b=1)
+    assert x_col == "beta_x_0"
+    assert y_col == "beta_x_1"
+    assert list(merged[x_col]) == [1.0, 2.0]
+    assert list(merged[y_col]) == [10.0, 20.0]
+
+
+def test_merge_drops_nan_rows():
+    """Rows with a NaN in either fit are dropped from the merge."""
+    import numpy as np
+
+    a = pd.DataFrame({"mutation": ["M1A", "M2B"], "beta_x": [1.0, np.nan]})
+    b = pd.DataFrame({"mutation": ["M1A", "M2B"], "beta_x": [10.0, 20.0]})
+    merged, _, _ = merge_two_fits_on_mutation(a, b, "beta_x", key_a=0, key_b=1)
+    assert len(merged) == 1

--- a/tests/test_dashboard_helpers.py
+++ b/tests/test_dashboard_helpers.py
@@ -11,6 +11,7 @@ from experiments.dashboard_helpers import (
     display_table_df,
     load_collection,
     selectable_columns,
+    synthesize_isin_query,
     varying_columns,
 )
 
@@ -133,3 +134,30 @@ def test_display_table_df_shape_and_rounding():
     assert 0.1235 in set(df["fusionreg"].round(4))
     # one row per fit, indices 0..2
     assert list(df["_fit_idx"]) == [0, 1, 2]
+
+
+def test_synthesize_query_uses_unrounded_values():
+    """Query is built from full-precision floats and round-trips selection."""
+    fm = _fit_models_fixture()
+    # select rows 0 and 1 (dataset A, fusionreg 0.0 and 0.123456)
+    q = synthesize_isin_query(fm, [0, 1])
+    selected = fm.reset_index(drop=True).query(q)
+    assert set(selected.index) == {0, 1}
+    # un-rounded float present verbatim (not 0.1235)
+    assert "0.123456" in q
+
+
+def test_synthesize_query_isin_idiom_and_dataset_membership():
+    """The query uses ``.isin(...)`` and constrains dataset membership."""
+    fm = _fit_models_fixture()
+    q = synthesize_isin_query(fm, [0, 2])  # datasets A and B
+    selected = fm.reset_index(drop=True).query(q)
+    assert set(selected["dataset_name"]) == {"A", "B"}
+    assert ".isin(" in q
+
+
+def test_synthesize_query_all_rows_returns_all():
+    """Selecting every fit yields a query that returns every fit."""
+    fm = _fit_models_fixture()
+    q = synthesize_isin_query(fm, [0, 1, 2])
+    assert len(fm.reset_index(drop=True).query(q)) == 3

--- a/tests/test_dashboard_helpers.py
+++ b/tests/test_dashboard_helpers.py
@@ -72,11 +72,43 @@ def test_load_collection_wraps_fit_models_shaped_object(tmp_path, monkeypatch):
     assert captured["wrapped"] == not_a_collection
 
 
+def test_load_collection_passes_through_existing_collection(tmp_path, monkeypatch):
+    """An already-``ModelCollection`` pickle is returned unchanged, not re-wrapped."""
+    import experiments.dashboard_helpers as helpers
+
+    constructed = {"n": 0}
+
+    class _StubMC:
+        """Stand-in collection that counts constructor calls."""
+
+        def __init__(self, loaded=None):
+            constructed["n"] += 1
+
+    monkeypatch.setattr(helpers, "ModelCollection", _StubMC)
+
+    already = _StubMC()  # one construction here; none expected in load_collection
+    assert constructed["n"] == 1
+
+    # Stub the unpickling step so we don't depend on the (unpicklable) local
+    # class round-tripping through the pickle module; load_collection's branch
+    # logic is what's under test, not pickle itself.
+    p = tmp_path / "mc.pkl"
+    p.write_bytes(b"ignored")
+    monkeypatch.setattr(helpers.pickle, "load", lambda _f: already)
+
+    result = load_collection(p)
+
+    assert result is already  # passthrough: same instance, returned unchanged
+    assert constructed["n"] == 1  # no NEW _StubMC built inside load_collection
+
+
 def test_load_collection_raises_on_garbage(tmp_path):
     """A non-pickle file raises so the caller can show a friendly error."""
+    import pickle
+
     p = tmp_path / "bad.pkl"
     p.write_bytes(b"not a pickle at all")
-    with pytest.raises(Exception):
+    with pytest.raises((pickle.UnpicklingError, EOFError)):
         load_collection(p)
 
 
@@ -91,6 +123,7 @@ def _fit_models_fixture():
             "ge_kwargs": [{"k": 1}, {"k": 1}, {"k": 1}],  # excluded (object)
             "beta_init": [object(), object(), object()],  # excluded (_init)
             "total_loss_training": [[1, 2], [1, 2], [1, 2]],  # excluded
+            "total_loss_validation": [0.1, 0.2, 0.3],  # excluded (_loss_validation)
             "model": [object(), object(), object()],  # excluded (model)
         }
     )
@@ -103,6 +136,9 @@ def test_selectable_columns_drops_model_and_bookkeeping():
     assert "ge_kwargs" not in cols
     assert "beta_init" not in cols
     assert "total_loss_training" not in cols
+    # validation loss is the sibling of training loss; both must be dropped so
+    # they don't clutter the selector table after add_eval_loss() was called.
+    assert "total_loss_validation" not in cols
     assert {"dataset_name", "fusionreg", "l2reg", "converged"} <= set(cols)
 
 
@@ -132,8 +168,10 @@ def test_display_table_df_shape_and_rounding():
     assert "_fit_idx" in df.columns
     assert "model" not in df.columns
     assert "l2reg" not in df.columns  # constant -> hidden
-    # rounding: 0.123456 -> 0.1235
-    assert 0.1235 in set(df["fusionreg"].round(4))
+    # rounding is applied to the STORED value (assert on the cell directly, not
+    # on a re-rounded copy, so an unrounded implementation would fail here).
+    assert df["fusionreg"].iloc[1] == pytest.approx(0.1235)
+    assert df["fusionreg"].iloc[1] != pytest.approx(0.123456)
     # one row per fit, indices 0..2
     assert list(df["_fit_idx"]) == [0, 1, 2]
 

--- a/tests/test_dashboard_helpers.py
+++ b/tests/test_dashboard_helpers.py
@@ -1,0 +1,72 @@
+"""Unit tests for the dashboard's pure helper functions."""
+
+from pathlib import Path
+
+import pytest
+
+from experiments.dashboard_helpers import (
+    discover_pickles,
+    load_collection,
+)
+
+
+def _touch(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"")
+
+
+def test_discover_pickles_finds_all_pkls_labeled_by_relative_path(tmp_path):
+    """Every ``*.pkl`` is found and labeled by its path relative to root."""
+    _touch(tmp_path / "a" / "fit_collection.pkl")
+    _touch(tmp_path / "b" / "deep" / "other.pkl")
+    found = discover_pickles(tmp_path)
+    assert set(found.keys()) == {"a/fit_collection.pkl", "b/deep/other.pkl"}
+    for label, path in found.items():
+        assert path.is_absolute()
+        assert str(path.relative_to(tmp_path)) == label
+
+
+def test_discover_pickles_includes_dot_dirs_and_is_sorted(tmp_path):
+    """Dot-directory matches are kept and entries are sorted by path."""
+    _touch(tmp_path / "z.pkl")
+    _touch(tmp_path / ".worktrees" / "x" / "m.pkl")
+    _touch(tmp_path / "a.pkl")
+    found = discover_pickles(tmp_path)
+    assert list(found.keys()) == [".worktrees/x/m.pkl", "a.pkl", "z.pkl"]
+
+
+def test_discover_pickles_empty_when_none(tmp_path):
+    """An empty mapping is returned when no pkl exists below the root."""
+    assert discover_pickles(tmp_path) == {}
+
+
+def test_load_collection_wraps_fit_models_shaped_object(tmp_path, monkeypatch):
+    """A non-collection pickle is coerced via ``ModelCollection(loaded)``."""
+    import pickle
+
+    import experiments.dashboard_helpers as helpers
+
+    captured = {}
+
+    class _StubMC:
+        def __init__(self, loaded):
+            captured["wrapped"] = loaded
+
+    # Patch the name load_collection looks up so we don't build a real fit.
+    monkeypatch.setattr(helpers, "ModelCollection", _StubMC)
+
+    not_a_collection = {"fit_models": "stand-in"}
+    p = tmp_path / "c.pkl"
+    p.write_bytes(pickle.dumps(not_a_collection))
+
+    result = load_collection(p)
+    assert isinstance(result, _StubMC)
+    assert captured["wrapped"] == not_a_collection
+
+
+def test_load_collection_raises_on_garbage(tmp_path):
+    """A non-pickle file raises so the caller can show a friendly error."""
+    p = tmp_path / "bad.pkl"
+    p.write_bytes(b"not a pickle at all")
+    with pytest.raises(Exception):
+        load_collection(p)

--- a/tests/test_dashboard_helpers.py
+++ b/tests/test_dashboard_helpers.py
@@ -197,3 +197,29 @@ def test_merge_drops_nan_rows():
     b = pd.DataFrame({"mutation": ["M1A", "M2B"], "beta_x": [10.0, 20.0]})
     merged, _, _ = merge_two_fits_on_mutation(a, b, "beta_x", key_a=0, key_b=1)
     assert len(merged) == 1
+
+
+def _muts_indexed_by_mutation():
+    """Mimic ``Model.get_mutations_df()``: mutation is the index, not a col."""
+    df = pd.DataFrame(
+        {"mutation": ["M1A", "M2B"], "beta_x": [1.0, 2.0], "shift_y": [3.0, 4.0]}
+    )
+    return df.set_index("mutation")
+
+
+def test_merge_handles_mutation_as_index():
+    """``get_mutations_df`` returns mutation as the index; merge must cope."""
+    a = _muts_indexed_by_mutation()
+    b = _muts_indexed_by_mutation()
+    assert "mutation" not in a.columns  # guard: index, not column
+    merged, x_col, y_col = merge_two_fits_on_mutation(a, b, "beta_x", key_a=7, key_b=9)
+    assert x_col == "beta_x_7"
+    assert y_col == "beta_x_9"
+    assert list(merged[x_col]) == [1.0, 2.0]
+
+
+def test_common_param_columns_handles_mutation_as_index():
+    """Common-param detection also works when mutation is the index."""
+    a = _muts_indexed_by_mutation()
+    b = _muts_indexed_by_mutation()
+    assert common_param_columns(a, b) == ["beta_x", "shift_y"]

--- a/tests/test_dashboard_helpers.py
+++ b/tests/test_dashboard_helpers.py
@@ -2,11 +2,16 @@
 
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from experiments.dashboard_helpers import (
+    constant_summary,
     discover_pickles,
+    display_table_df,
     load_collection,
+    selectable_columns,
+    varying_columns,
 )
 
 
@@ -70,3 +75,61 @@ def test_load_collection_raises_on_garbage(tmp_path):
     p.write_bytes(b"not a pickle at all")
     with pytest.raises(Exception):
         load_collection(p)
+
+
+def _fit_models_fixture():
+    """A small ``fit_models``-shaped DataFrame for table-builder tests."""
+    return pd.DataFrame(
+        {
+            "dataset_name": ["A", "A", "B"],
+            "fusionreg": [0.0, 0.123456, 0.0],
+            "l2reg": [0.0, 0.0, 0.0],
+            "converged": [True, True, False],
+            "ge_kwargs": [{"k": 1}, {"k": 1}, {"k": 1}],  # excluded (object)
+            "beta_init": [object(), object(), object()],  # excluded (_init)
+            "total_loss_training": [[1, 2], [1, 2], [1, 2]],  # excluded
+            "model": [object(), object(), object()],  # excluded (model)
+        }
+    )
+
+
+def test_selectable_columns_drops_model_and_bookkeeping():
+    """``model`` and ``*_init``/``*_kwargs``/``*_loss_training`` are dropped."""
+    cols = selectable_columns(_fit_models_fixture())
+    assert "model" not in cols
+    assert "ge_kwargs" not in cols
+    assert "beta_init" not in cols
+    assert "total_loss_training" not in cols
+    assert {"dataset_name", "fusionreg", "l2reg", "converged"} <= set(cols)
+
+
+def test_varying_columns_only_nonconstant():
+    """Only columns that differ across at least two fits are reported."""
+    varying = varying_columns(_fit_models_fixture())
+    assert "fusionreg" in varying  # 0.0 vs 0.123456
+    assert "dataset_name" in varying  # A vs B
+    assert "l2reg" not in varying  # all 0.0
+    assert "model" not in varying
+
+
+def test_constant_summary_reports_constants_only():
+    """Constant selectable columns appear; varying columns do not."""
+    summary = constant_summary(_fit_models_fixture())
+    assert summary["l2reg"] == 0.0
+    assert "fusionreg" not in summary
+    assert "model" not in summary
+
+
+def test_display_table_df_shape_and_rounding():
+    """Table starts with dataset_name, hides constants, keeps ``_fit_idx``."""
+    df = display_table_df(_fit_models_fixture(), round_to=4)
+    # dataset_name first, converged present, _fit_idx retained
+    assert list(df.columns)[0] == "dataset_name"
+    assert "converged" in df.columns
+    assert "_fit_idx" in df.columns
+    assert "model" not in df.columns
+    assert "l2reg" not in df.columns  # constant -> hidden
+    # rounding: 0.123456 -> 0.1235
+    assert 0.1235 in set(df["fusionreg"].round(4))
+    # one row per fit, indices 0..2
+    assert list(df["_fit_idx"]) == [0, 1, 2]


### PR DESCRIPTION
## Summary

Generalizes the marimo dashboard (`experiments/dashboard.py`) so it can explore
**any** fitted `ModelCollection`, switching which model(s) are plotted across the
full hyperparameter grid — and fixes the launch-time `NameError`.

Three changes, matching the three requirements in the issue:

- **R1 — launch `NameError` fixed.** The old `_discover_collections` helper was
  defined at module top level but called inside a marimo cell, which marimo's
  cell-scope rule forbids. All pure logic now lives in a new importable module
  `experiments/dashboard_helpers.py`, and the cells `import` it (a cell-level
  import is visible to that cell). No application logic remains at module scope
  except `app = marimo.App(...)`.
- **R2 — recursive `*.pkl` discovery + lazy validation.** `discover_pickles`
  finds every `*.pkl` below cwd (no directory pruning), labeled by path relative
  to cwd **including the filename**, sorted. Each pickle is validated **lazily on
  selection** via `load_collection` (pickle.load → coerce to `ModelCollection`);
  a non-collection pickle surfaces a friendly inline error (`mo.stop`) without
  crashing the app or dropping the file from the dropdown. The module docstring
  and empty-state message were updated off `fit_collection.pkl`.
- **R3 — per-tab fit-selection tables.** The five hard-coded
  `dataset_name`/`fusionreg` dropdowns (plus the `mc._conditions`-derived scatter
  param dropdown) are gone. Each interactive tab now carries its own `mo.ui.table`
  built from `fit_models`, showing `dataset_name` + the varying hyperparameter
  columns + `converged`, with the constant columns summarized in a caption. Float
  columns are rounded **for display only**; queries are synthesized from the
  **un-rounded** source values via `.isin([...])` membership. Selection contracts:
  GE = single, Convergence = multi, Sparsity = multi (≥2 fusionreg),
  Param Correlation = multi (≥2 datasets), Replicate Scatter = exactly 2.

## New pure, unit-tested helpers (`experiments/dashboard_helpers.py`)

`discover_pickles`, `load_collection`, `selectable_columns`, `varying_columns`,
`constant_summary`, `display_table_df`, `synthesize_isin_query`,
`common_param_columns`, `merge_two_fits_on_mutation` — all covered by
`tests/test_dashboard_helpers.py` (15 tests) and the re-pointed
`tests/test_dashboard_discovery.py` (5 tests).

## Verification

- ✅ Full CI suite green: `pixi run test` → **218 passed** (unit + doctests).
- ✅ **Real-browser end-to-end (Playwright).** The live dashboard was launched
  from an *arbitrary* fixture directory (not the repo root) against a 54-fit
  `ModelCollection`, and driven in Chrome with zero console errors:
  - recursive discovery dropdown lists both pickles by relative-path-incl.-
    filename;
  - selecting a junk (non-collection) pickle surfaces a graceful inline
    `mo.stop` error without crashing the app;
  - selecting the valid collection loads it ("Loaded **54** fits") and every
    per-tab table builds with its varying columns + constant-summary caption;
  - checking two rows in the Convergence table renders a live convergence
    Vega chart (the multi-fit overlay R3 promises).
  - This launch-from-arbitrary-cwd run is what exposed deviation 5 (the
    `experiments.`-qualified import); the earlier `marimo.App.embed()` checks
    ran from the repo root and so could not have caught it.

## No package changes

Only `experiments/` and tests change. `multidms/model_collection.py` and
`multidms/plot.py` already forward `query=`/`times_seen_threshold=` through
`**kwargs` (`split_apply_combine_muts`, `convergence_trajectory_df`,
`shift_sparsity`, `mut_param_dataset_correlation`), so no package code was
touched.

## Deviations from spec

1. **Helper location (planned, user-approved).** The issue's R1 says the
   discovery helper should be "defined inside a cell and returned." Instead, the
   pure logic lives in a new importable module `experiments/dashboard_helpers.py`
   that the cells `import`. This fully meets R1's stated acceptance ("the
   dashboard launches with no `NameError`") because a cell-level import is visible
   to that cell, while additionally (a) preserving the existing import-based
   `tests/test_dashboard_discovery.py` and (b) making the R3 logic unit-testable.
   This was explicitly approved during planning.

2. **`mo.ui.table.value` is a DataFrame, not a list of dicts (discovered during
   implementation).** The plan assumed `mo.ui.table(...).value` returns selected
   rows as a list of dicts (`[r["_fit_idx"] for r in sel]`). In the installed
   marimo (0.23.11) it returns a **pandas DataFrame** of the selected rows;
   iterating it yields column-name strings and raised `TypeError: string indices
   must be integers`. All five selection-handling cells were rewritten to use the
   DataFrame API: indices via `list(sel["_fit_idx"])`, emptiness via `sel.empty`,
   single-row access via `int(sel["_fit_idx"].iloc[0])`. The `_fit_idx`
   round-trip contract (display table → query/merge keys) is unchanged.

3. **Scatter param-dropdown cell ordering.** The plan listed the scatter chart
   cell before the param-dropdown cell; they are emitted in dependency order
   (dropdown first) for readability. marimo orders cells by their reactive
   dependency graph regardless of source position, so this is cosmetic.

4. **`mutation` is the index of `get_mutations_df()`, not a column (found by
   real-data testing).** The plan's `merge_two_fits_on_mutation` /
   `common_param_columns` assumed a `mutation` *column*. The real
   `Model.get_mutations_df()` returns the mutation string as the DataFrame
   *index* (`index.name == "mutation"`), so the Replicate Scatter tab crashed
   with `KeyError: ['mutation'] not in index`. Fixed by normalizing both inputs
   through a `_with_mutation_column()` helper that resets the index to a column
   when needed. Caught by executing every chart branch (GE, Convergence,
   Sparsity, Correlation, Scatter) against a real 54-fit collection — all five
   now produce charts; Scatter merges 1000 mutations with correct fit-keyed
   columns. Locked with two regression tests.

5. **Helper must be imported as a top-level module, not `experiments.`-qualified
   (found by real-browser testing).** The cells originally did
   `from experiments.dashboard_helpers import ...`. That only resolves when the
   repo root is on `sys.path` — i.e. when launched from the repo root. marimo
   puts the **notebook's own directory** (`experiments/`) on `sys.path` but *not*
   the repo root, so launching the dashboard from any results directory below cwd
   — the entire point of R2 ("discovers every `*.pkl` below the directory the
   dashboard was launched from") — failed with `ModuleNotFoundError: No module
   named 'experiments'`, killing every cell and rendering a blank page with only
   the header. The earlier `marimo.App.embed()` / empty-selection checks ran from
   the repo root and so masked this. Fixed by importing the sibling as the
   top-level module `from dashboard_helpers import ...` (launch-cwd-independent),
   plus an AST-based regression test asserting `dashboard.py` never reintroduces
   the qualified form. Verified end-to-end by driving the live dashboard in
   Chrome (Playwright) launched from an arbitrary fixture dir: recursive
   discovery dropdown, friendly inline error on a junk pickle, valid 54-fit load,
   per-tab selection table, and a live convergence chart on multi-row selection —
   all with zero console errors.

Closes #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

