### PR TITLE
Convergence-lab: l2reg tames the β-explosion across the fusionreg axis (#256)

### DIFF
--- a/experiments/convergence-lab/README.md
+++ b/experiments/convergence-lab/README.md
@@ -45,6 +45,17 @@ directory run `pixi run dashboard` (it discovers `fit_collection.pkl` below cwd)
   equally well, so noise decides which one each replicate lands in.
 - **L2 knee near `3e-4`**; double-ended degeneracy: β explodes at `l2reg=0`,
   β collapses + α explodes at `l2reg ≥ 1e-3`.
+- **A small `l2reg>0` tames the β-explosion across the whole prod fusion axis**
+  (measured, #256, `cache=l2-fusion`): at `l2reg=0` Σβ² sits at ~16–19k for
+  *every* `fusionreg` (0 → 6.4e-4); `l2reg=1e-4` collapses it ~25× into the
+  healthy 350–840 band and `3e-4` further to ~190–300, both holding at the
+  prod-max `fusionreg=6.4e-4`. `1e-4` is the working weight (α ~20–25); `3e-4`
+  over-regularizes toward the see-saw's collapse end (α ~30–40). **Strong
+  fusion is reproducibility-rescued only once β is penalized:** at `l2reg=0`
+  the `6.4e-4` column collapses `shift_Delta` replicate-r to 0.09, but at
+  `l2reg=1e-4` strong fusion *lifts* `shift_Omicron_BA2` r to 0.80 — the
+  data-poor-condition distortion the path-fitter targets is itself a symptom
+  of the unpenalized β-explosion.
 - **`recompute_scale=False`** (the fixed-scale objective normalizer) converges.
 - **`fit_models` parallelism — settled** (`diagnostics/parallelism_probe.py`):
   `n_processes=2` (the real spawn path) ran the full data-size × l2reg staircase
@@ -66,6 +77,11 @@ directory run `pixi run dashboard` (it discovers `fit_collection.pkl` below cwd)
 (Append one entry per harness run: date, cache name, config swept, what the
 fit collection showed — basin diagnostics and replicate correlation computed
 downstream from a ModelCollection — the conclusion, the next step.)
+
+- 2026-06-30 | cache=l2-fusion | sweep: l2reg [0.0, 1e-4, 3e-4] × fusionreg [0.0, 4e-5, 6.4e-4], 2 reps (18 fits), warmstart=True, recompute_scale=False, share_alpha=True, Sigmoid, maxiter=25. Independent fitting (#256). Wall 1138s at n_processes=4 (local, Apple M4 Max). Downstream numbers from diagnostics/l2_fusion_report.py.
+  Basin diagnostics (Σβ², α per cell): at l2reg=0.0 → Σβ² 16,181–19,222, α 5.9–8.2 (β EXPLODED at EVERY fusionreg, incl. 6.4e-4). l2reg=1e-4 → Σβ² 554–841, α 19.5–24.6 (β tamed ~25× into the healthy 350–1400 band, holds across all fusion). l2reg=3e-4 → Σβ² 188–298, α 30.5–40.4 (β tamed further but α climbing toward the see-saw collapse end). All 18 converged=False, but final_obj_err is tiny (4e-6 at l2reg=0 to ~7e-4 at l2reg>0) — maxiter=25 truncation, not a pathology; β-magnitude and r are trustworthy, the binary flag is not.
+  Replicate-shift Pearson r (per l2reg slice, across fusionreg 0/4e-5/6.4e-4): l2reg=0 → shift_Delta 0.45/0.50/0.09, shift_Omicron_BA2 0.26/0.43/0.20 (strong fusion COLLAPSES shift_Delta at l2reg=0 — the unpenalized-β regime). l2reg=1e-4 → shift_Delta 0.47/0.45/0.33, shift_Omicron_BA2 0.37/0.43/0.80 (strong fusion now LIFTS shift_Omicron_BA2 to 0.80). l2reg=3e-4 → shift_Delta 0.40/0.37/0.41, shift_Omicron_BA2 0.43/0.49/0.76.
+  Conclusion: a small l2reg>0 SOLVES the β-explosion across the entire prod fusion axis; l2reg=1e-4 is the working weight (β healthy, α not yet over-driven). The data-poor-condition distortion under strong fusion is itself a symptom of the unpenalized explosion — once β is penalized, strong fusion rescues rather than wrecks replicate-r (shift_Omicron_BA2 0.20→0.80 at fusionreg=6.4e-4). Standing findings updated (L2-knee finding extended to 2-D). Next: maxiter sweep at l2reg=1e-4 to convert the tiny-but-nonzero final_obj_err into converged=True; optionally a continuation-path comparison along fusionreg at l2reg=1e-4 (separate experiment — independent fitting already suffices to tame β).
 
 - 2026-06-26 | cache=smoke | sweep: l2reg [0.0, 3e-4], warmstart=True, recompute_scale=False, fusionreg=0.0, Sigmoid, maxiter=25.
   df_fits (4 fits, ~185s/fit, wall 740s): at l2reg=0.0 -> alpha 7.4-8.2, Sigma-beta^2 36,785-40,371 (beta EXPLODED); at l2reg=3e-4 -> alpha 36-40, Sigma-beta^2 438-626 (beta collapsed, alpha exploded). All 4 converged=False (final_obj_err ~4-6e-6 at l2reg=0, ~3e-4 at l2reg=3e-4).

--- a/experiments/convergence-lab/diagnostics/l2_fusion_report.py
+++ b/experiments/convergence-lab/diagnostics/l2_fusion_report.py
@@ -1,0 +1,155 @@
+r"""Downstream report for the l2-fusion β-explosion sweep (#256).
+
+Loads a convergence-lab ``fit_collection.pkl`` into a ``ModelCollection``
+and prints a per-cell table of basin diagnostics (Σβ², α, converged,
+final_obj_err) plus replicate-shift Pearson r per ``l2reg`` slice. The
+harness only fits; this computes the derived metrics on the fly, matching
+the convergence-lab design (nothing derived is stored in the pickle).
+
+The ``l2reg=0`` rows are the β-explosion control; success is at least one
+``l2reg>0`` value showing bounded Σβ² + α across all three fusion
+strengths, with replicate-r that does not collapse as fusionreg rises.
+
+Run::
+
+    pixi run python experiments/convergence-lab/diagnostics/l2_fusion_report.py \\
+        --cache l2-fusion
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+import sys
+import warnings
+from pathlib import Path
+
+os.environ.setdefault("XLA_FLAGS", "--xla_cpu_multi_thread_eigen=false")
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
+
+warnings.filterwarnings("ignore")
+
+import pandas as pd  # noqa: E402
+
+# Reuse the harness's RESULTS_DIR / path constants.
+sys.path.insert(0, str(Path(os.path.abspath(__file__)).parent.parent))
+import harness  # noqa: E402
+
+from multidms.model_collection import ModelCollection  # noqa: E402
+
+
+def basin_row(fit) -> dict:
+    """Extract basin diagnostics from one fit-collection row.
+
+    Args:
+        fit: A row (``pd.Series``) of the fit-collection frame; ``fit.model``
+            is a fitted ``multidms.Model``.
+
+    Returns:
+        Dict with ``l2reg``, ``fusionreg``, ``dataset_name``, ``sum_beta_sq``
+        (Σβ² of the reference condition's mutation effects), ``alpha`` (shared
+        scalar), ``converged`` (bool), and ``final_obj_err``.
+    """
+    model = fit.model
+    ref = model.data.reference
+    beta = model.params.φ[ref].β
+    sum_beta_sq = float((beta**2).sum())
+    alpha = float(model.params.α)
+    try:
+        final_obj_err = float(
+            model.convergence_trajectory_df["objective_error_trajectory"].iloc[-1]
+        )
+    except (TypeError, KeyError, IndexError):
+        final_obj_err = float("nan")
+    return {
+        "l2reg": fit.l2reg,
+        "fusionreg": fit.fusionreg,
+        "dataset_name": fit.dataset_name,
+        "sum_beta_sq": sum_beta_sq,
+        "alpha": alpha,
+        "converged": bool(model.converged),
+        "final_obj_err": final_obj_err,
+    }
+
+
+def basin_table(frame: pd.DataFrame) -> pd.DataFrame:
+    """Per-fit basin diagnostics for the whole collection.
+
+    Args:
+        frame: The raw fit-collection DataFrame.
+
+    Returns:
+        One row per fit, sorted by ``(l2reg, fusionreg, dataset_name)``.
+    """
+    rows = [basin_row(frame.iloc[i]) for i in range(len(frame))]
+    return (
+        pd.DataFrame(rows)
+        .sort_values(["l2reg", "fusionreg", "dataset_name"])
+        .reset_index(drop=True)
+    )
+
+
+def replicate_corr_table(frame: pd.DataFrame) -> pd.DataFrame:
+    """Replicate-shift Pearson r across fusionreg, per l2reg slice.
+
+    ``mut_param_dataset_correlation`` groups correlation by ``(dataset_name,
+    fusionreg)``, so it must be run once per ``l2reg`` level to avoid mixing
+    l2 regimes. Returns the concatenated per-slice correlation frames, each
+    tagged with its ``l2reg``. The underlying frame carries a ``mut_param``
+    column (the shift, e.g. ``shift_Delta``), so each ``(l2reg, fusionreg)``
+    cell yields one row per shift.
+
+    Args:
+        frame: The raw fit-collection DataFrame.
+
+    Returns:
+        Concatenated correlation frames (columns ``datasets``, ``mut_param``,
+        ``correlation``, ``fusionreg`` plus an ``l2reg`` tag), or an empty
+        frame if no slice has ≥2 datasets.
+    """
+    mc = ModelCollection(frame)
+    out = []
+    for l2 in sorted(frame["l2reg"].unique()):
+        try:
+            _, df = mc.mut_param_dataset_correlation(
+                x="fusionreg",
+                return_data=True,
+                r=1,
+                query=f"l2reg == {l2}",
+            )
+        except ValueError:
+            # Fewer than 2 datasets in this slice — skip it honestly.
+            continue
+        df = df.copy()
+        df["l2reg"] = l2
+        out.append(df)
+    return pd.concat(out, ignore_index=True) if out else pd.DataFrame()
+
+
+def main() -> None:
+    """CLI: ``--cache <name>`` → print basin + replicate-r tables."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--cache",
+        default="l2-fusion",
+        help="results subdir holding fit_collection.pkl (default: l2-fusion)",
+    )
+    args = ap.parse_args()
+
+    pkl = harness.RESULTS_DIR / args.cache / "fit_collection.pkl"
+    frame = pickle.load(open(pkl, "rb"))
+    print(f"[report] loaded {len(frame)} fits from {pkl}\n")
+
+    basin = basin_table(frame)
+    with pd.option_context("display.width", 200, "display.max_rows", 50):
+        print("=== basin diagnostics (per fit) ===")
+        print(basin.to_string(index=False))
+        print("\n=== replicate-shift Pearson r (per l2reg slice) ===")
+        corr = replicate_corr_table(frame)
+        print(corr.to_string(index=False) if len(corr) else "(no ≥2-dataset slice)")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/convergence-lab/diagnostics/test_l2_fusion_report.py
+++ b/experiments/convergence-lab/diagnostics/test_l2_fusion_report.py
@@ -1,0 +1,47 @@
+"""Smoke test for the l2-fusion report's per-fit metric extraction."""
+
+import os
+import pickle
+import sys
+from pathlib import Path
+
+import pytest
+
+DIAG = Path(__file__).resolve().parent
+sys.path.insert(0, str(DIAG))
+
+
+def _sample_pickle() -> Path | None:
+    """Locate a sample fit_collection.pkl to extract from.
+
+    The simulation collection is gitignored, so it is absent from a fresh
+    checkout (and from a worktree, where ``results/`` is never materialized).
+    Honor a ``L2_FUSION_TEST_PKL`` env override (point it at the canonical
+    clone's copy when running from a worktree); otherwise fall back to the
+    in-tree path. Returns ``None`` when no fixture is reachable, so the test
+    skips rather than fails.
+    """
+    override = os.environ.get("L2_FUSION_TEST_PKL")
+    if override and Path(override).exists():
+        return Path(override)
+    in_tree = (
+        Path(__file__).resolve().parents[3]
+        / "experiments/simulation/results/fit_collection.pkl"
+    )
+    return in_tree if in_tree.exists() else None
+
+
+@pytest.mark.skipif(
+    _sample_pickle() is None,
+    reason="needs a sample fit_collection.pkl (set L2_FUSION_TEST_PKL)",
+)
+def test_basin_row_extracts_finite_numbers():
+    """basin_row returns finite Σβ², α, and a bool converged for a real fit."""
+    import l2_fusion_report as rpt
+
+    frame = pickle.load(open(_sample_pickle(), "rb"))
+    row = frame.iloc[0]
+    out = rpt.basin_row(row)
+    assert out["sum_beta_sq"] >= 0.0
+    assert isinstance(out["converged"], bool)
+    assert out["alpha"] == out["alpha"]  # not NaN

--- a/experiments/convergence-lab/grids/l2-fusion.yaml
+++ b/experiments/convergence-lab/grids/l2-fusion.yaml
@@ -1,0 +1,16 @@
+# l2-fusion grid (#256) — does an l2reg penalty tame the β-explosion across
+# the prod fusionreg axis? 3 l2reg × 3 fusionreg × 2 reps = 18 fits.
+# Diagnostic confirmation, NOT hyperparameter tuning. Independent fitting only.
+sweep:
+  l2reg: [0.0, 1.0e-4, 3.0e-4]          # control (explosion) + 2 candidate fixes, below the 3e-4 knee
+  fusionreg: [0.0, 4.0e-5, 6.4e-4]      # prod sweep: no-fusion, positional midpoint (lasso_choice), prod max
+fixed:
+  warmstart: true
+  recompute_scale: false                # scale held fixed (#246) — never recomputed
+  share_alpha: true
+  ge_type: Sigmoid
+  maxiter: 25                           # diagnostic, capped for speed (same as smoke)
+  tol: 1.0e-6
+  ge_kwargs: {tol: 1.0e-4, maxiter: 20, maxls: 40, jit: true}
+  cal_kwargs: {tol: 1.0e-4, maxiter: 20, maxls: 40, jit: true}
+replicates: [1, 2]


### PR DESCRIPTION
Closes #256

## Summary

One new convergence-lab experiment: a 3×3 `l2reg × fusionreg` grid (2 reps, **18 fits**) on the scv2-spike prod data, run locally in ~19 min, confirming that a small `l2reg>0` penalty **tames the β-explosion across the entire prod fusion axis** — and surfacing a strong secondary finding about how shift-lasso strength interacts with replicate reproducibility.

**No library code changes.** This is a new grid YAML + a downstream analysis script + a run + a lab-notebook entry, all consuming the existing generic harness from #255.

| Piece | What it does |
|---|---|
| `grids/l2-fusion.yaml` | The grid: `l2reg ∈ {0, 1e-4, 3e-4}` × `fusionreg ∈ {0, 4e-5, 6.4e-4}` (three genuine prod-sweep values) × 2 reps. Held-fixed config mirrors the proven `smoke.yaml` (`warmstart=True`, `recompute_scale=False`, `share_alpha=True`, Sigmoid, `maxiter=25`). |
| `diagnostics/l2_fusion_report.py` | Loads the resulting `fit_collection.pkl` into a `ModelCollection` and prints per-cell basin diagnostics (Σβ², α, converged, final_obj_err) + replicate-shift Pearson r **per `l2reg` slice** (correlation is grouped by `fusionreg`, so it must be sliced by `l2reg` to avoid mixing regimes). |
| `diagnostics/test_l2_fusion_report.py` | TDD smoke test for the metric extraction, verified green against a real `multidms.Model`. |
| `README.md` | Run-log entry + Standing-findings update (the lab notebook). |

## Results

**Basin diagnostics — the β-explosion is solved at every fusion strength:**

| `l2reg` | Σβ² (all fusion) | α | Verdict |
|---|---|---|---|
| `0.0` (control) | 16,181 – 19,222 | 5.9 – 8.2 | β **exploded** |
| `1e-4` | 554 – 841 | 19.5 – 24.6 | ✓ β tamed ~25× into the healthy 350–1400 band |
| `3e-4` | 188 – 298 | 30.5 – 40.4 | ✓ β tamed further, but α climbing toward the see-saw collapse end |

**`l2reg=1e-4` is the working weight** — it brings Σβ² into the healthy band at every `fusionreg` up to the prod max `6.4e-4`, without over-driving α the way `3e-4` does.

**Replicate-shift Pearson r — strong fusion *rescues* reproducibility once β is penalized:**

At `l2reg=0`, the strong-fusion column (`6.4e-4`) *collapses* `shift_Delta` to r=0.09 — the data-poor-condition distortion the path-fitter was built for. Add `l2reg=1e-4` and that collapse disappears; strong fusion then *lifts* `shift_Omicron_BA2` to r=0.80 (from 0.20 at `l2reg=0`). The lasso distortion is itself a symptom of the unpenalized β-explosion.

> ⚠ **Convergence caveat:** all 18 fits report `converged=False`, but `final_obj_err` is tiny (4e-6 at `l2reg=0` to ~7e-4 at `l2reg>0`). This is `maxiter=25` truncation (intentional, for speed), not a pathology — β-magnitude and replicate-r are trustworthy; the binary flag is not. Next experiment: a maxiter sweep at `l2reg=1e-4` to convert that into `converged=True`.

Explore the fits interactively: from `experiments/convergence-lab/` run `pixi run dashboard` (it discovers `results/l2-fusion/fit_collection.pkl`).

## Testing

- `diagnostics/test_l2_fusion_report.py`: 1 passed — `basin_row` extraction verified against a real `multidms.Model` (honors `L2_FUSION_TEST_PKL` so it runs from a worktree where gitignored `results/` is not materialized).
- `tests/test_convergence_lab_harness.py`: 9 passed, 1 deselected — harness unaffected by the new config.
- Config validated through the harness allowlist (18 cells, correct l2reg/fusionreg/replicate values).
- Run executed end-to-end on real prod data: **18/18 fit, 0 failed**, wall 1138s at `n_processes=4`; pickle loads as a `ModelCollection`.
- ruff + black clean on the new `.py` files.

## Deviations from spec

- **Worktree data + fixture symlinks (operational, not a design change).** The harness's `DATA_CSV` and the test's simulation-pickle fixture both live in gitignored directories that are not materialized inside a git worktree. The **first run crashed instantly** on the missing CSV. Fixed without touching code (the spec forbids harness changes): symlinked the canonical clone's gitignored `results-prod-235-times-seen-threshold/` data dir into the worktree, and made the test honor an `L2_FUSION_TEST_PKL` env override (falling back to the in-tree path). Neither symlink is committed (both gitignored). This is the same worktree-isolation gotcha the spec's env-symlink note anticipates, extended to data + fixtures.
- **Report emits a richer correlation table than the spec's metric list.** `mut_param_dataset_correlation` returns r for *all* mutation parameters (`beta_*`, `predicted_func_score_*`, `shift_*`), not just the shifts. The script prints the full table; the run-log highlights the `shift_*` rows the experiment is about. No filtering was added — surfacing the extra rows is informative and harmless.
- **Standing-findings update (additive).** Beyond the required run-log entry, the result *extended* the existing "L2 knee near 3e-4" standing finding to a 2-D (`l2reg × fusionreg`) statement, per the directory `CLAUDE.md` instruction to update standing findings when a result confirms/extends one.
- Otherwise the implementation matched the spec exactly (grid, held-fixed config, independent fitting only, no continuation, no hyperparameter tuning, no library changes, local memory-capped run).

Yolo trail: spec gate ✓, plan gate ✓ — full log in `_ignore/yolo/256.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
