### PR TITLE
Fix convergence trajectory lines collapsing across selected fits

### DIFF
--- a/experiments/dashboard.py
+++ b/experiments/dashboard.py
@@ -194,16 +194,17 @@ def _(mo):
 
 
 @app.cell
-def _(conv_table, mc, mo, mplot, synthesize_isin_query):
+def _(conv_table, mc, mo, mplot):
     _sel = conv_table.value  # a DataFrame of selected rows (may be empty)
     if _sel is None or _sel.empty:
         convergence_chart = mo.md("Select at least one fit.")
     else:
         _idx = list(_sel["_fit_idx"])
-        _query = synthesize_isin_query(mc.fit_models, _idx)
-        _conv_df = mc.convergence_trajectory_df(query=_query)
+        _conv_df = mc.convergence_trajectory_df(fit_indices=_idx)
         convergence_chart = mplot.convergence_trajectory(
-            _conv_df, id_cols=["dataset_name", "fusionreg"]
+            _conv_df,
+            id_cols=["_fit_idx"],
+            tooltip_cols=["dataset_name", "fusionreg"],
         )
     return (convergence_chart,)
 

--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -983,32 +983,47 @@ class ModelCollection:
         self,
         query=None,
         id_vars=("dataset_name", "fusionreg"),
+        fit_indices=None,
     ):
         """
-        Combine the converence trajectory dataframes of
-        all fits in the queried collection.
-        """
-        queried_fits = (
-            self.fit_models.query(query) if query is not None else self.fit_models
-        )
-        if len(queried_fits) == 0:
-            raise ValueError("invalid query, no fits returned")
+        Combine the convergence trajectory dataframes of the selected fits.
 
-        if not all([var in queried_fits.columns for var in id_vars]):
+        Fits are selected either by ``query`` (a pandas query string over
+        ``fit_models``) or by ``fit_indices`` (positional row indices into
+        ``fit_models.reset_index(drop=True)``); the two are mutually
+        exclusive. When ``fit_indices`` is given, each fit's trajectory block
+        is stamped with a ``_fit_idx`` column equal to that fit's positional
+        index, giving a stable one-per-fit identifier for plotting.
+        """
+        if query is not None and fit_indices is not None:
+            raise ValueError("pass at most one of query= or fit_indices=")
+
+        if fit_indices is not None:
+            indices = list(fit_indices)
+            selected = self.fit_models.reset_index(drop=True).iloc[indices]
+        else:
+            indices = None
+            selected = (
+                self.fit_models.query(query) if query is not None else self.fit_models
+            )
+
+        if len(selected) == 0:
+            raise ValueError("invalid selection, no fits returned")
+
+        if not all([var in selected.columns for var in id_vars]):
             raise ValueError(f"invalid {id_vars=}")
 
-        convergence_trajectory_data = my_concat(
-            [
-                (
-                    fit.model.convergence_trajectory_df.assign(
-                        **{key: fit[key] for key in id_vars}
-                    )
-                )
-                for _, fit in queried_fits.iterrows()
-            ]
-        )
+        rows = list(selected.iterrows())
+        blocks = []
+        for i, (_, fit) in enumerate(rows):
+            block = fit.model.convergence_trajectory_df.assign(
+                **{key: fit[key] for key in id_vars}
+            )
+            if indices is not None:
+                block = block.assign(_fit_idx=indices[i])
+            blocks.append(block)
 
-        return convergence_trajectory_data
+        return my_concat(blocks)
 
     def plot_convergence_trajectory(
         self,

--- a/multidms/plot.py
+++ b/multidms/plot.py
@@ -726,6 +726,7 @@ def convergence_trajectory(
     *,
     x="iteration",
     id_cols=None,
+    tooltip_cols=None,
     trajectory_groups=None,
     init_group="loss",
     log_y=True,
@@ -755,6 +756,12 @@ def convergence_trajectory(
         ``['dataset_name', 'fusionreg']``). Each unique combination
         gets a distinct line style. If None, no model identity
         distinction is made.
+    tooltip_cols : list of str or None
+        Extra columns to carry into the hover tooltip (e.g.
+        ``['dataset_name', 'fusionreg']``). Any name present in ``df`` and
+        not already in ``id_cols`` is preserved through the melt and shown
+        on hover. These do NOT contribute to line identity (``model_id``);
+        grouping is determined by ``id_cols`` alone.
     trajectory_groups : dict or None
         Mapping from group name to list of column names. If None,
         auto-detected from the DataFrame using canonical groupings
@@ -808,12 +815,21 @@ def convergence_trajectory(
     # Build id columns
     if id_cols is None:
         id_cols = []
-    keep_cols = [x] + id_cols + value_cols
+
+    # Extra columns to preserve for tooltips only (not for line identity).
+    if tooltip_cols is None:
+        tooltip_cols = []
+    extra_tooltip_cols = [
+        c for c in tooltip_cols if c in df.columns and c not in id_cols
+    ]
+
+    melt_id_vars = [x] + id_cols + extra_tooltip_cols
+    keep_cols = melt_id_vars + value_cols
     keep_cols = [c for c in keep_cols if c in df.columns]
 
     # Melt to long form
     long_df = df[keep_cols].melt(
-        id_vars=[x] + id_cols,
+        id_vars=[c for c in melt_id_vars if c in df.columns],
         value_vars=[c for c in value_cols if c in df.columns],
         var_name="metric",
         value_name="value",
@@ -854,6 +870,8 @@ def convergence_trajectory(
     ]
     if id_cols:
         tooltip_fields.append(alt.Tooltip("model_id:N", title="model"))
+    for col in extra_tooltip_cols:
+        tooltip_fields.append(alt.Tooltip(f"{col}:N"))
 
     base = alt.Chart(long_df).transform_filter(group_selector)
 

--- a/tests/test_model_collection.py
+++ b/tests/test_model_collection.py
@@ -624,6 +624,20 @@ class TestConvergenceTrajectoryDf:
         df = collection.convergence_trajectory_df(query="fusionreg == 0.0")
         assert all(df["fusionreg"] == 0.0)
 
+    def test_fit_indices_selection_stamps_fit_idx(self, collection):
+        idx = [0, 1]
+        df = collection.convergence_trajectory_df(fit_indices=idx)
+        assert "_fit_idx" in df.columns
+        assert set(df["_fit_idx"].unique()) == set(idx)
+        # one contiguous block per selected fit (no interleaving of indices)
+        assert df["_fit_idx"].nunique() == len(idx)
+
+    def test_fit_indices_and_query_mutually_exclusive(self, collection):
+        with pytest.raises(ValueError):
+            collection.convergence_trajectory_df(
+                query="fusionreg == 0.0", fit_indices=[0]
+            )
+
 
 # ========== Visualization smoke tests ==========
 

--- a/tests/test_model_collection.py
+++ b/tests/test_model_collection.py
@@ -699,6 +699,28 @@ class TestVisualization:
         # Verify chart produces a valid Vega-Lite spec
         chart.to_dict()
 
+    def test_convergence_trajectory_groups_by_fit_idx(self, collection):
+        """One line per selected fit; tooltip cols survive but don't group."""
+        import multidms.plot
+
+        idx = [0, 1]
+        df = collection.convergence_trajectory_df(fit_indices=idx)
+        chart = multidms.plot.convergence_trajectory(
+            df,
+            id_cols=["_fit_idx"],
+            tooltip_cols=["dataset_name", "fusionreg"],
+        )
+        chart.to_dict()  # valid spec
+
+        # The top-level chart.data carries the melted long_df for both
+        # log_y=True (LayerChart) and log_y=False (plain Chart). Assert the
+        # tooltip columns survived and that model_id has exactly one distinct
+        # value per selected fit (the fix: N selected fits => N lines).
+        data = chart.data
+        assert "dataset_name" in data.columns
+        assert "fusionreg" in data.columns
+        assert data["model_id"].nunique() == len(idx)
+
     def test_plot_convergence_trajectory_standalone(self, collection):
         """Test the standalone plot.convergence_trajectory function."""
         import altair as alt


### PR DESCRIPTION
Closes #259

## Summary

In the marimo dashboard's **Convergence** tab, selecting two or more fits drew all their trajectories as a **single connected line**. Root cause: the cell hardcoded `id_cols=["dataset_name","fusionreg"]`, so any two selected fits sharing that pair but differing on another hyperparameter (`scale_coeff_lasso_shift`, `l2reg`, …) collapsed to the same `model_id` and `mark_line()` connected them into one zig-zag.

The fix groups lines by a **stable per-fit index** carried from the selection all the way into the trajectory data.

### Changes (one commit per task)

1. **`multidms/model_collection.py`** — `convergence_trajectory_df` gains a `fit_indices=` selection path (positional indices into `fit_models`), mutually exclusive with `query=`. Each selected fit's trajectory block is stamped with a `_fit_idx` column — a stable one-per-fit identifier. Existing `query=`/`id_vars=` behavior is unchanged.
2. **`multidms/plot.py`** — `convergence_trajectory` gains a `tooltip_cols=` param. Named columns present in the frame (and not already in `id_cols`) are carried **through the melt** into the hover tooltip. They do **not** contribute to `model_id`, so grouping stays keyed on `id_cols` alone. (This carry-through is required: `keep_cols` drops non-id/non-value columns before the melt, so a "tooltip when present" guard alone would be a no-op.)
3. **`experiments/dashboard.py`** — the Convergence cell now selects by `fit_indices=_idx` and calls `convergence_trajectory(..., id_cols=["_fit_idx"], tooltip_cols=["dataset_name","fusionreg"])`. One selection = one line, guaranteed. `synthesize_isin_query` is no longer used by this cell (still used by the correlation/sparsity cells).

### Testing

- `test_fit_indices_selection_stamps_fit_idx` — `_fit_idx` column takes exactly the selected indices, one block per fit.
- `test_fit_indices_and_query_mutually_exclusive` — passing both raises `ValueError`.
- `test_convergence_trajectory_groups_by_fit_idx` — with `id_cols=["_fit_idx"]`, `model_id.nunique() == len(selected)` (the fix: N fits ⇒ N lines), and `dataset_name`/`fusionreg` survive into the chart data for the tooltip.
- Full slow `test_model_collection.py` suite: **79 passed**. Default suite: 52 passed. Doctests on touched modules: pass. `ruff check .`: clean. `black --check` on touched files: clean.

## Deviations from spec

- **Manual dashboard verification not performed live.** The spec's Testing section calls for launching `pixi run dashboard` and visually confirming "N selected fits ⇒ N distinct lines" against a real `fit_collection.pkl`. That requires a fitted pickle with ≥2 fits sharing `(dataset_name, fusionreg)` but differing on another axis, plus a browser — not scriptable in this environment. The automated `test_convergence_trajectory_groups_by_fit_idx` stands in: it asserts the exact invariant (`model_id.nunique() == number of selected fits`) on the chart's underlying melted data, plus tooltip-column survival. A reviewer with a suitable local pickle can still do the visual check.
- **Plan test commands needed `-m slow`.** `tests/test_model_collection.py` is module-marked `pytest.mark.slow` and the default pytest `addopts` is `-m 'not slow'`, so the new tests only run under `pixi run -- pytest ... -m slow`. This is a test-invocation detail, not a code deviation; the tests themselves match the plan.
- Otherwise the implementation matches the spec exactly (all three files, the `_fit_idx` grouping decision, and the `tooltip_cols` carry-through mechanism).

Yolo trail: spec gate ✓, plan gate ✓ — full log in _ignore/yolo/259.log
