### PR TITLE
Skip dot-hidden paths in dashboard pkl discovery (#258)

### DIFF
--- a/experiments/dashboard_helpers.py
+++ b/experiments/dashboard_helpers.py
@@ -25,24 +25,35 @@ EXCLUDED_TABLE_SUFFIXES = ("_loss_training", "_loss_validation", "_init", "_kwar
 
 
 def discover_pickles(root):
-    """Find every ``*.pkl`` below ``root``.
+    """Find every ``*.pkl`` below ``root``, skipping dot-hidden paths.
+
+    Any match whose path *relative to* ``root`` contains a dot-prefixed
+    directory component (e.g. ``.worktrees/``, ``.git/``, ``.pixi/``) is
+    pruned, so stray or duplicate collections buried in hidden trees do
+    not pollute the picker. Only components *below* ``root`` are tested:
+    ``root`` may itself sit inside a dot-hidden directory (e.g. when the
+    dashboard is launched from within a ``.worktrees`` checkout) without
+    suppressing everything beneath it. A dot in the *filename* does not
+    prune — only directory components count. Visible directories,
+    including ``results/``, are kept.
 
     Args:
         root: Directory searched recursively (typically ``Path.cwd()``).
 
     Returns:
         Ordered mapping of ``label -> absolute Path``, one entry per
-        ``*.pkl`` found anywhere below ``root``. ``label`` is the pickle's
-        path relative to ``root`` *including the filename* (filenames now
-        differ between matches). Entries are sorted by path. No directories
-        are pruned: matches under ``.worktrees/``, ``.pixi/``, ``results/``
-        etc. are intentionally included.
+        ``*.pkl`` found below ``root`` outside any dot-hidden directory.
+        ``label`` is the pickle's path relative to ``root`` *including
+        the filename* (filenames may differ between matches). Entries are
+        sorted by path.
     """
     root = Path(root)
     discovered = {}
     for p in sorted(root.rglob("*.pkl")):
-        label = str(p.relative_to(root))
-        discovered[label] = p
+        rel = p.relative_to(root)
+        if any(part.startswith(".") for part in rel.parent.parts):
+            continue
+        discovered[str(rel)] = p
     return discovered
 
 

--- a/tests/test_dashboard_discovery.py
+++ b/tests/test_dashboard_discovery.py
@@ -45,15 +45,42 @@ def test_matches_any_pkl_extension(tmp_path):
     }
 
 
-def test_no_pruning_includes_dot_dirs(tmp_path):
-    """Matches under dot-directories (.worktrees, .pixi) are not pruned."""
-    _touch(tmp_path / ".worktrees" / "x" / "fit_collection.pkl")
-    _touch(tmp_path / ".pixi" / "y" / "a.pkl")
+def test_prunes_dot_hidden_dirs(tmp_path):
+    """Matches under a dot-hidden directory component are pruned.
+
+    Stray or duplicate collections buried in hidden trees (``.worktrees``,
+    ``.pixi``, ``.git``, a nested ``.hidden``) must not pollute the picker,
+    while visible directories such as ``results/`` are kept. A dot in the
+    *filename* does not prune — only directory components count.
+    """
+    _touch(tmp_path / ".worktrees" / "x" / "fit_collection.pkl")  # pruned
+    _touch(tmp_path / ".pixi" / "y" / "a.pkl")  # pruned
+    _touch(tmp_path / ".git" / "g.pkl")  # pruned
+    _touch(tmp_path / "sub" / ".hidden" / "c.pkl")  # pruned (nested)
+    _touch(tmp_path / "results" / "run1" / "fit_collection.pkl")  # kept
+    _touch(tmp_path / "top.pkl")  # kept
 
     found = discover_pickles(tmp_path)
 
-    assert ".worktrees/x/fit_collection.pkl" in found
-    assert ".pixi/y/a.pkl" in found
+    assert set(found.keys()) == {
+        "results/run1/fit_collection.pkl",
+        "top.pkl",
+    }
+
+
+def test_dot_hidden_root_keeps_visible_descendants(tmp_path):
+    """Only components *below* root are tested, so a dot-hidden root works.
+
+    When the dashboard is launched from inside a ``.worktrees`` checkout,
+    ``root`` itself lives under a dot-hidden directory; pickles in its
+    visible subdirectories must still be discovered.
+    """
+    root = tmp_path / ".worktrees" / "258-x"
+    _touch(root / "results" / "f.pkl")
+
+    found = discover_pickles(root)
+
+    assert set(found.keys()) == {"results/f.pkl"}
 
 
 def test_empty_when_none_present(tmp_path):

--- a/tests/test_dashboard_helpers.py
+++ b/tests/test_dashboard_helpers.py
@@ -34,13 +34,17 @@ def test_discover_pickles_finds_all_pkls_labeled_by_relative_path(tmp_path):
         assert str(path.relative_to(tmp_path)) == label
 
 
-def test_discover_pickles_includes_dot_dirs_and_is_sorted(tmp_path):
-    """Dot-directory matches are kept and entries are sorted by path."""
+def test_discover_pickles_is_sorted(tmp_path):
+    """Discovered entries are ordered deterministically by path.
+
+    Dot-hidden pruning is covered in ``test_dashboard_discovery.py``;
+    this only guards the sort order of the kept, visible entries.
+    """
     _touch(tmp_path / "z.pkl")
-    _touch(tmp_path / ".worktrees" / "x" / "m.pkl")
     _touch(tmp_path / "a.pkl")
+    _touch(tmp_path / "m" / "n.pkl")
     found = discover_pickles(tmp_path)
-    assert list(found.keys()) == [".worktrees/x/m.pkl", "a.pkl", "z.pkl"]
+    assert list(found.keys()) == ["a.pkl", "m/n.pkl", "z.pkl"]
 
 
 def test_discover_pickles_empty_when_none(tmp_path):


### PR DESCRIPTION
## Summary

`discover_pickles()` (the marimo dashboard's recursive `*.pkl` sweep in
`experiments/dashboard_helpers.py`) descended into dot-hidden trees —
`.worktrees/`, `.git/`, `.pixi/`, `.bipartite/` — surfacing stray or
duplicate `ModelCollection` pickles in the picker dropdown.

This PR prunes any match whose path **relative to `root`** contains a
dot-prefixed directory component. Only components *below* `root` are
tested, so:

- launching the dashboard from *inside* a `.worktrees/` checkout still
  finds pickles in that checkout's visible subdirectories (root's own
  dot-hidden prefix does not disqualify everything beneath it);
- a dot in the **filename** does not prune — only directory components
  count;
- `results/` and all other visible directories are kept.

The `discover_pickles` docstring, which previously advertised the old
"no directories are pruned … intentionally included" behavior verbatim,
is rewritten to describe the pruning.

## What changed vs. the plan

- **Test placement.** The plan assumed no `discover_pickles` test file
  existed and proposed a new `tests/test_dashboard_helpers.py` with a
  `sys.path` import trick. On opening the worktree, **two** existing test
  files already covered discovery — `tests/test_dashboard_discovery.py`
  (the dedicated home) and `tests/test_dashboard_helpers.py` — both
  importing via `from experiments.dashboard_helpers import …` (the repo
  root is on pytest's `sys.path`, so no trick is needed). I adapted to
  the existing structure instead: the dot-hidden behavior lives in the
  dedicated `test_dashboard_discovery.py`, and I removed the planned
  duplicate coverage.
- **Two existing tests asserted the OLD behavior** and had to be flipped,
  not merely added alongside:
  - `test_dashboard_discovery.py::test_no_pruning_includes_dot_dirs`
    → `test_prunes_dot_hidden_dirs` (now asserts exclusion), plus a new
    `test_dot_hidden_root_keeps_visible_descendants` edge case.
  - `test_dashboard_helpers.py::test_discover_pickles_includes_dot_dirs_and_is_sorted`
    → `test_discover_pickles_is_sorted` (sort-order guard only; pruning
    is covered in the dedicated file, avoiding duplicate discovery tests
    across two files).

## Testing

- `pytest --doctest-modules multidms tests` → **53 passed**
- `ruff check .` → clean
- `black --check` (changed files) → clean

## Deviations from spec

- **Test file location.** The spec/plan said to add a *new*
  `tests/test_dashboard_helpers.py` (and originally
  `experiments/tests/…`) with a `sys.path.insert` import shim. The
  implementation instead **edited the two pre-existing discovery test
  files** and used the codebase's established `from
  experiments.dashboard_helpers import …` import style (no `sys.path`
  trick — pytest's rootdir already makes it importable). This is a purer
  match to existing conventions and avoids duplicating discovery
  coverage; the acceptance criteria (dot-hidden excluded, visible incl.
  `results/` kept, root-under-dot-dir works, docstring accurate,
  CI-collected tests green) are all met. The `sys.path` shim the plan
  described was based on the incorrect assumption that no discovery test
  file existed.
- No other deviations. `dashboard.py`, `load_collection`, other helpers,
  config, and `results/`/label-formatting logic are untouched; pruning
  is unconditional (no flag).

Yolo trail: spec gate ✓, plan gate ✓ — full log in `_ignore/yolo/258.log`

Closes #258
