### PR TITLE
Add space="func_score" view to the GE landscape API

### DIFF
--- a/experiments/dashboard.py
+++ b/experiments/dashboard.py
@@ -220,11 +220,33 @@ def _(ge_table, mc, mo, mplot):
     else:
         _row = mc.fit_models.reset_index(drop=True).iloc[int(_sel["_fit_idx"].iloc[0])]
         _model = _row["model"]
-        _variants_df, _ge_curve_df = _model.get_ge_landscape_df()
         _max_points = 5000
-        if len(_variants_df) > _max_points:
-            _variants_df = _variants_df.sample(n=_max_points, random_state=0)
-        ge_chart = mplot.ge_landscape(_variants_df, _ge_curve_df, point_size=20)
+
+        def _sampled_variants(_vdf):
+            if len(_vdf) > _max_points:
+                return _vdf.sample(n=_max_points, random_state=0)
+            return _vdf
+
+        _v_fit, _curve_fit = _model.get_ge_landscape_df(space="fitness")
+        _fit_chart = mplot.ge_landscape(
+            _sampled_variants(_v_fit), _curve_fit, space="fitness", point_size=20
+        )
+
+        _v_fs, _curve_fs = _model.get_ge_landscape_df(space="func_score")
+        _fs_chart = mplot.ge_landscape(
+            _sampled_variants(_v_fs), _curve_fs, space="func_score", point_size=20
+        )
+
+        ge_chart = mo.vstack(
+            [
+                mo.md("**Fitness space** — g(φ)"),
+                _fit_chart,
+                mo.md(
+                    "**Functional-score space** — " "α·(g(φ) − g(φ_wt)), per condition"
+                ),
+                _fs_chart,
+            ]
+        )
     return (ge_chart,)
 
 

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -841,7 +841,7 @@ class Model:
         func_score_curve = pd.concat(curve_rows, ignore_index=True)
         return variants_df, func_score_curve
 
-    def plot_ge_landscape(self, n_curve_points=200, **kwargs):
+    def plot_ge_landscape(self, n_curve_points=200, space="fitness", **kwargs):
         """Plot the global epistasis landscape.
 
         Convenience wrapper that calls :meth:`get_ge_landscape_df` and
@@ -850,7 +850,12 @@ class Model:
         Parameters
         ----------
         n_curve_points : int
-            Number of points for the ``g(φ)`` curve grid. Default 200.
+            Number of points for the curve grid. Default 200.
+        space : str
+            ``"fitness"`` (default) plots the shared ``g(φ)`` curve;
+            ``"func_score"`` plots one predicted-functional-score curve per
+            condition. Passed to both :meth:`get_ge_landscape_df` and
+            :func:`multidms.plot.ge_landscape`.
         **kwargs
             Passed to :func:`multidms.plot.ge_landscape`.
 
@@ -861,10 +866,10 @@ class Model:
         """
         import multidms.plot
 
-        variants_df, ge_curve_df = self.get_ge_landscape_df(
-            n_curve_points=n_curve_points
+        variants_df, curve_df = self.get_ge_landscape_df(
+            n_curve_points=n_curve_points, space=space
         )
-        return multidms.plot.ge_landscape(variants_df, ge_curve_df, **kwargs)
+        return multidms.plot.ge_landscape(variants_df, curve_df, space=space, **kwargs)
 
     def get_ge_curve(
         self,

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -749,53 +749,97 @@ class Model:
     def get_ge_landscape_df(
         self,
         n_curve_points: int = 200,
+        space: str = "fitness",
     ) -> tuple:
         """Get data for plotting the global epistasis landscape.
 
-        Returns a tuple of (variants_df, ge_curve_df). The variants DataFrame
+        Returns a tuple of ``(variants_df, curve_df)``. ``variants_df``
         contains per-variant latent phenotype and fitness columns from
         :meth:`get_variants_df`, plus a ``wildtype_latent`` column for
-        reference-line plotting. The curve DataFrame contains the global
-        epistasis function evaluated over the observed latent phenotype range.
+        reference-line plotting. The curve DataFrame depends on ``space``.
 
         Parameters
         ----------
         n_curve_points : int
-            Number of points for the ``g(φ)`` curve grid.
+            Number of points for the curve grid.
+        space : str
+            Which landscape to build. ``"fitness"`` (default) returns the
+            shared global-epistasis curve ``g(φ)``. ``"func_score"`` returns
+            one predicted-functional-score curve per condition,
+            ``α · (g(φ) − g(φ_wt))``.
 
         Returns
         -------
         tuple[pd.DataFrame, pd.DataFrame]
-            ``(variants_df, ge_curve_df)`` where:
+            ``(variants_df, curve_df)`` where:
 
             - ``variants_df`` has all columns from :meth:`get_variants_df`
               plus ``wildtype_latent``.
-            - ``ge_curve_df`` has columns ``predicted_latent`` and
-              ``ge_curve_value``.
+            - For ``space="fitness"``: ``curve_df`` has columns
+              ``predicted_latent`` and ``ge_curve_value``.
+            - For ``space="func_score"``: ``curve_df`` is long-form with
+              columns ``condition``, ``predicted_latent``, and
+              ``func_score_curve_value`` (``n_conditions × n_curve_points``
+              rows).
         """
+        if space not in ("fitness", "func_score"):
+            raise ValueError(
+                f"space must be 'fitness' or 'func_score', got {space!r}"
+            )
+
         variants_df = self.get_variants_df()
 
-        # Compute ge curve spanning the observed latent range
+        # Shared global latent grid (computed once, spans ALL conditions)
         φ_min = variants_df["predicted_latent"].min()
         φ_max = variants_df["predicted_latent"].max()
         margin = (φ_max - φ_min) * 0.05
-        ge_curve = self.get_ge_curve(
-            grid_min=float(φ_min - margin),
-            grid_max=float(φ_max + margin),
-            n_points=n_curve_points,
-        )
-        ge_curve = ge_curve.rename(
-            columns={
-                "latent": "predicted_latent",
-                "observed": "ge_curve_value",
-            }
-        )
+        grid_min = float(φ_min - margin)
+        grid_max = float(φ_max + margin)
 
-        # Add wildtype latent to variants_df for reference lines
+        # Add wildtype latent to variants_df for reference lines (both modes)
         wt_latent = self.wildtype_latent
         variants_df["wildtype_latent"] = variants_df["condition"].map(wt_latent)
 
-        return variants_df, ge_curve
+        if space == "fitness":
+            ge_curve = self.get_ge_curve(
+                grid_min=grid_min,
+                grid_max=grid_max,
+                n_points=n_curve_points,
+            )
+            ge_curve = ge_curve.rename(
+                columns={
+                    "latent": "predicted_latent",
+                    "observed": "ge_curve_value",
+                }
+            )
+            return variants_df, ge_curve
+
+        # space == "func_score": one curve per condition
+        import jax.numpy as jnp
+
+        grid = jnp.linspace(grid_min, grid_max, n_curve_points)
+        g_grid = np.array(self._jax_model.global_epistasis(grid))
+        grid_np = np.array(grid)
+
+        _α = self._jax_model.α
+        curve_rows = []
+        for condition in self._data.conditions:
+            α = float(_α[condition] if isinstance(_α, dict) else _α)
+            g_wt = float(
+                self._jax_model.global_epistasis(jnp.array(wt_latent[condition]))
+            )
+            curve_vals = α * (g_grid - g_wt)
+            curve_rows.append(
+                pd.DataFrame(
+                    {
+                        "condition": condition,
+                        "predicted_latent": grid_np,
+                        "func_score_curve_value": curve_vals,
+                    }
+                )
+            )
+        func_score_curve = pd.concat(curve_rows, ignore_index=True)
+        return variants_df, func_score_curve
 
     def plot_ge_landscape(self, n_curve_points=200, **kwargs):
         """Plot the global epistasis landscape.

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -783,9 +783,7 @@ class Model:
               rows).
         """
         if space not in ("fitness", "func_score"):
-            raise ValueError(
-                f"space must be 'fitness' or 'func_score', got {space!r}"
-            )
+            raise ValueError(f"space must be 'fitness' or 'func_score', got {space!r}")
 
         variants_df = self.get_variants_df()
 

--- a/multidms/plot.py
+++ b/multidms/plot.py
@@ -1350,7 +1350,7 @@ def func_score_boxplot(variants_df, *, width=400, height=300):
 def ge_landscape(
     variants_df,
     ge_curve_df,
-    fitness_col="measured_fitness",
+    fitness_col=None,
     color_by="condition",
     point_size=5,
     point_opacity=0.3,
@@ -1358,6 +1358,7 @@ def ge_landscape(
     curve_width=3,
     width=500,
     height=400,
+    space="fitness",
 ):
     """Plot the global epistasis landscape.
 
@@ -1373,12 +1374,16 @@ def ge_landscape(
         ``condition``, ``wildtype_latent``, and ``fitness_col``.
         Typically from :meth:`Model.get_ge_landscape_df`.
     ge_curve_df : pandas.DataFrame
-        Global epistasis curve with columns ``predicted_latent``
-        and ``ge_curve_value``.
+        Curve DataFrame. For ``space="fitness"`` it has columns
+        ``predicted_latent`` and ``ge_curve_value``; for
+        ``space="func_score"`` it is long-form with ``condition``,
+        ``predicted_latent`` and ``func_score_curve_value``.
         Typically from :meth:`Model.get_ge_landscape_df`.
-    fitness_col : str
-        Which fitness column to plot on the y-axis: ``'measured_fitness'``
-        or ``'predicted_fitness'``. Default is ``'measured_fitness'``.
+    fitness_col : str, optional
+        Which variant column to plot on the y-axis. When ``None`` (the
+        default), resolves per ``space``: ``'measured_fitness'`` for
+        ``space="fitness"`` and ``'predicted_func_score'`` for
+        ``space="func_score"``.
     color_by : str
         Column to color scatter points by. Default is ``'condition'``.
     point_size : float
@@ -1393,6 +1398,11 @@ def ge_landscape(
         Chart width in pixels. Default is 500.
     height : int
         Chart height in pixels. Default is 400.
+    space : str
+        ``"fitness"`` (default) draws the single shared ``g(φ)`` curve on
+        ``ge_curve_value``. ``"func_score"`` draws one condition-colored
+        curve per condition on ``func_score_curve_value`` and labels the
+        y-axis "Functional score".
 
     Returns
     -------
@@ -1400,6 +1410,16 @@ def ge_landscape(
         Altair layered chart with scatter, curve, and wildtype reference
         lines.
     """
+    if space not in ("fitness", "func_score"):
+        raise ValueError(
+            f"space must be 'fitness' or 'func_score', got {space!r}"
+        )
+    if fitness_col is None:
+        fitness_col = (
+            "predicted_func_score" if space == "func_score" else "measured_fitness"
+        )
+    y_title = "Functional score" if space == "func_score" else "Fitness"
+
     # Interactive legend selection to toggle conditions
     selection = alt.selection_point(fields=[color_by], bind="legend")
 
@@ -1412,7 +1432,7 @@ def ge_landscape(
                 "predicted_latent:Q",
                 title="Predicted latent phenotype (φ)",
             ),
-            y=alt.Y(f"{fitness_col}:Q", title="Fitness"),
+            y=alt.Y(f"{fitness_col}:Q", title=y_title),
             color=alt.Color(f"{color_by}:N"),
             opacity=alt.condition(
                 selection,
@@ -1423,15 +1443,28 @@ def ge_landscape(
         .add_params(selection)
     )
 
-    # Curve layer: g(φ)
-    curve = (
-        alt.Chart(ge_curve_df)
-        .mark_line(color=curve_color, strokeWidth=curve_width)
-        .encode(
-            x="predicted_latent:Q",
-            y=alt.Y("ge_curve_value:Q"),
+    # Curve layer
+    if space == "func_score":
+        # one line per condition from α·(g(φ) − g(φ_wt))
+        curve = (
+            alt.Chart(ge_curve_df)
+            .mark_line(strokeWidth=curve_width)
+            .encode(
+                x="predicted_latent:Q",
+                y=alt.Y("func_score_curve_value:Q", title=y_title),
+                color=alt.Color(f"{color_by}:N"),
+                detail=alt.Detail(f"{color_by}:N"),
+            )
         )
-    )
+    else:
+        curve = (
+            alt.Chart(ge_curve_df)
+            .mark_line(color=curve_color, strokeWidth=curve_width)
+            .encode(
+                x="predicted_latent:Q",
+                y=alt.Y("ge_curve_value:Q"),
+            )
+        )
 
     # WT reference lines
     wt_data = (

--- a/multidms/plot.py
+++ b/multidms/plot.py
@@ -1380,10 +1380,14 @@ def ge_landscape(
         ``predicted_latent`` and ``func_score_curve_value``.
         Typically from :meth:`Model.get_ge_landscape_df`.
     fitness_col : str, optional
-        Which variant column to plot on the y-axis. When ``None`` (the
-        default), resolves per ``space``: ``'measured_fitness'`` for
-        ``space="fitness"`` and ``'predicted_func_score'`` for
-        ``space="func_score"``.
+        Which variant column to scatter on the y-axis. When ``None`` (the
+        default), resolves to the *measured* observation for each space:
+        ``'measured_fitness'`` for ``space="fitness"`` and ``'func_score'``
+        for ``space="func_score"``. The model's prediction is the curve
+        itself (``predicted_func_score`` equals the per-condition curve
+        evaluated at each variant's latent), so the scatter shows measured
+        data and the curve shows the fit; the vertical gap is the residual.
+        Pass ``'predicted_func_score'`` explicitly to overlay predictions.
     color_by : str
         Column to color scatter points by. Default is ``'condition'``.
     point_size : float
@@ -1413,9 +1417,11 @@ def ge_landscape(
     if space not in ("fitness", "func_score"):
         raise ValueError(f"space must be 'fitness' or 'func_score', got {space!r}")
     if fitness_col is None:
-        fitness_col = (
-            "predicted_func_score" if space == "func_score" else "measured_fitness"
-        )
+        # Default to the *measured* observation in each space, so the scatter
+        # shows data (not model predictions) against the fitted curve:
+        #   fitness    -> measured_fitness  (observed, in g(φ) space)
+        #   func_score -> func_score        (observed functional score)
+        fitness_col = "func_score" if space == "func_score" else "measured_fitness"
     y_title = "Functional score" if space == "func_score" else "Fitness"
 
     # Interactive legend selection to toggle conditions

--- a/multidms/plot.py
+++ b/multidms/plot.py
@@ -1411,9 +1411,7 @@ def ge_landscape(
         lines.
     """
     if space not in ("fitness", "func_score"):
-        raise ValueError(
-            f"space must be 'fitness' or 'func_score', got {space!r}"
-        )
+        raise ValueError(f"space must be 'fitness' or 'func_score', got {space!r}")
     if fitness_col is None:
         fitness_col = (
             "predicted_func_score" if space == "func_score" else "measured_fitness"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1253,8 +1253,22 @@ def test_ge_landscape_plot_func_score_space(fitted_simple_model):
 
 
 def test_plot_ge_landscape_func_score_convenience(fitted_simple_model):
-    """Model.plot_ge_landscape(space='func_score') returns a LayerChart."""
+    """Model.plot_ge_landscape(space='func_score') binds the func_score curve.
+
+    The wrapper must call get_ge_landscape_df(space='func_score') so the curve
+    layer's data actually carries ``func_score_curve_value``. We inspect the
+    serialized spec's shared datasets (Altair stores layer data by reference
+    under top-level ``datasets``) to confirm the column is present — a wrapper
+    that passed a fitness-space df would bind only ``ge_curve_value``.
+    """
     import altair as alt
 
     chart = fitted_simple_model.plot_ge_landscape(space="func_score")
     assert isinstance(chart, alt.LayerChart)
+
+    spec = chart.to_dict()
+    all_columns = set()
+    for rows in spec.get("datasets", {}).values():
+        for row in rows:
+            all_columns.update(row.keys())
+    assert "func_score_curve_value" in all_columns

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1246,6 +1246,28 @@ def test_ge_landscape_plot_func_score_space(fitted_simple_model):
     assert isinstance(chart, alt.LayerChart)
 
 
+def test_ge_landscape_func_score_scatters_measured_by_default(fitted_simple_model):
+    """func_score mode scatters MEASURED func_score, not the prediction.
+
+    The prediction is the curve itself (predicted_func_score equals the
+    per-condition curve at each variant's latent), so the informative scatter
+    is the measured func_score; its vertical offset from the curve is the
+    residual. Guards against defaulting the scatter back to
+    predicted_func_score, which would stipple dots onto the curve.
+    """
+    import multidms.plot as mplt
+
+    variants_df, curve_df = fitted_simple_model.get_ge_landscape_df(space="func_score")
+    spec = mplt.ge_landscape(variants_df, curve_df, space="func_score").to_dict()
+    y_fields = [
+        layer.get("encoding", {}).get("y", {}).get("field") for layer in spec["layer"]
+    ]
+    assert "func_score" in y_fields
+    assert "func_score_curve_value" in y_fields
+    # measured scatter must NOT default to the model prediction
+    assert "predicted_func_score" not in y_fields
+
+
 def test_plot_ge_landscape_func_score_convenience(fitted_simple_model):
     """Model.plot_ge_landscape(space='func_score') binds the func_score curve.
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1238,3 +1238,23 @@ def test_plot_ge_landscape_convenience(fitted_simple_model):
 
     chart = fitted_simple_model.plot_ge_landscape()
     assert isinstance(chart, alt.LayerChart)
+
+
+def test_ge_landscape_plot_func_score_space(fitted_simple_model):
+    """ge_landscape renders in func_score space and returns a LayerChart."""
+    import altair as alt
+    import multidms.plot as mplt
+
+    variants_df, curve_df = fitted_simple_model.get_ge_landscape_df(
+        space="func_score"
+    )
+    chart = mplt.ge_landscape(variants_df, curve_df, space="func_score")
+    assert isinstance(chart, alt.LayerChart)
+
+
+def test_plot_ge_landscape_func_score_convenience(fitted_simple_model):
+    """Model.plot_ge_landscape(space='func_score') returns a LayerChart."""
+    import altair as alt
+
+    chart = fitted_simple_model.plot_ge_landscape(space="func_score")
+    assert isinstance(chart, alt.LayerChart)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1159,6 +1159,56 @@ def test_get_ge_landscape_df_invalid_space(fitted_simple_model):
         fitted_simple_model.get_ge_landscape_df(space="bogus")
 
 
+def test_func_score_curve_reconstructs_variant_scores(fitted_simple_model):
+    """Curve formula at each variant's own φ reproduces predicted_func_score.
+
+    Evaluates α·(g(φ_i) − g(φ_wt)) at each variant's exact latent value and
+    checks it matches that variant's predicted_func_score. Catches a wrong α
+    application or a missing/incorrect g_wt subtraction — which the anchor
+    test cannot.
+    """
+    import jax.numpy as jnp
+
+    variants_df = fitted_simple_model.get_variants_df()
+    wt_latent = fitted_simple_model.wildtype_latent
+    _α = fitted_simple_model._jax_model.α
+    g = fitted_simple_model._jax_model.global_epistasis
+
+    for condition in fitted_simple_model.data.conditions:
+        sub = variants_df[variants_df["condition"] == condition]
+        α = float(_α[condition] if isinstance(_α, dict) else _α)
+        g_wt = float(g(jnp.array(wt_latent[condition])))
+        φ = jnp.array(sub["predicted_latent"].to_numpy())
+        expected = α * (np.array(g(φ)) - g_wt)
+        assert np.allclose(
+            expected, sub["predicted_func_score"].to_numpy(), atol=1e-5
+        )
+
+
+def test_func_score_curves_differ_across_conditions(fitted_simple_model):
+    """Conditions with different φ_wt produce different curves."""
+    _, curve_df = fitted_simple_model.get_ge_landscape_df(space="func_score")
+    conditions = list(fitted_simple_model.data.conditions)
+    assert len(conditions) >= 2
+    a = curve_df[curve_df["condition"] == conditions[0]][
+        "func_score_curve_value"
+    ].to_numpy()
+    b = curve_df[curve_df["condition"] == conditions[1]][
+        "func_score_curve_value"
+    ].to_numpy()
+    assert not np.allclose(a, b)
+
+
+def test_func_score_curve_monotonic_increasing(fitted_simple_model):
+    """Each condition's curve is monotonically increasing in φ (Sigmoid, α>0)."""
+    _, curve_df = fitted_simple_model.get_ge_landscape_df(space="func_score")
+    for condition in fitted_simple_model.data.conditions:
+        vals = curve_df[curve_df["condition"] == condition][
+            "func_score_curve_value"
+        ].to_numpy()
+        assert np.all(np.diff(vals) >= -1e-8)
+
+
 # ==================== ge_landscape Plot Tests ====================
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1116,6 +1116,49 @@ def test_get_ge_landscape_df_custom_curve_points(fitted_simple_model):
     assert len(ge_curve) == 50
 
 
+def test_get_ge_landscape_df_space_fitness_matches_default(fitted_simple_model):
+    """space='fitness' is byte-for-byte identical to the default call."""
+    v_default, c_default = fitted_simple_model.get_ge_landscape_df()
+    v_fitness, c_fitness = fitted_simple_model.get_ge_landscape_df(space="fitness")
+
+    pd.testing.assert_frame_equal(v_default, v_fitness)
+    pd.testing.assert_frame_equal(c_default, c_fitness)
+    assert list(c_fitness.columns) == ["predicted_latent", "ge_curve_value"]
+
+
+def test_get_ge_landscape_df_func_score_schema(fitted_simple_model):
+    """space='func_score' returns a long-form per-condition curve df."""
+    variants_df, curve_df = fitted_simple_model.get_ge_landscape_df(
+        space="func_score"
+    )
+    assert set(curve_df.columns) == {
+        "condition",
+        "predicted_latent",
+        "func_score_curve_value",
+    }
+    n_conditions = len(fitted_simple_model.data.conditions)
+    assert len(curve_df) == n_conditions * 200  # default n_curve_points
+    # variants_df still carries wildtype_latent for the renderer's WT rules
+    assert "wildtype_latent" in variants_df.columns
+
+
+def test_get_ge_landscape_df_func_score_custom_points(fitted_simple_model):
+    """n_curve_points controls per-condition point count in func_score mode."""
+    _, curve_df = fitted_simple_model.get_ge_landscape_df(
+        space="func_score", n_curve_points=50
+    )
+    n_conditions = len(fitted_simple_model.data.conditions)
+    assert len(curve_df) == n_conditions * 50
+    for condition in fitted_simple_model.data.conditions:
+        assert len(curve_df[curve_df["condition"] == condition]) == 50
+
+
+def test_get_ge_landscape_df_invalid_space(fitted_simple_model):
+    """An unknown space value raises a ValueError naming the options."""
+    with pytest.raises(ValueError, match="fitness.*func_score|func_score.*fitness"):
+        fitted_simple_model.get_ge_landscape_df(space="bogus")
+
+
 # ==================== ge_landscape Plot Tests ====================
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1128,9 +1128,7 @@ def test_get_ge_landscape_df_space_fitness_matches_default(fitted_simple_model):
 
 def test_get_ge_landscape_df_func_score_schema(fitted_simple_model):
     """space='func_score' returns a long-form per-condition curve df."""
-    variants_df, curve_df = fitted_simple_model.get_ge_landscape_df(
-        space="func_score"
-    )
+    variants_df, curve_df = fitted_simple_model.get_ge_landscape_df(space="func_score")
     assert set(curve_df.columns) == {
         "condition",
         "predicted_latent",
@@ -1180,9 +1178,7 @@ def test_func_score_curve_reconstructs_variant_scores(fitted_simple_model):
         g_wt = float(g(jnp.array(wt_latent[condition])))
         φ = jnp.array(sub["predicted_latent"].to_numpy())
         expected = α * (np.array(g(φ)) - g_wt)
-        assert np.allclose(
-            expected, sub["predicted_func_score"].to_numpy(), atol=1e-5
-        )
+        assert np.allclose(expected, sub["predicted_func_score"].to_numpy(), atol=1e-5)
 
 
 def test_func_score_curves_differ_across_conditions(fitted_simple_model):
@@ -1245,9 +1241,7 @@ def test_ge_landscape_plot_func_score_space(fitted_simple_model):
     import altair as alt
     import multidms.plot as mplt
 
-    variants_df, curve_df = fitted_simple_model.get_ge_landscape_df(
-        space="func_score"
-    )
+    variants_df, curve_df = fitted_simple_model.get_ge_landscape_df(space="func_score")
     chart = mplt.ge_landscape(variants_df, curve_df, space="func_score")
     assert isinstance(chart, alt.LayerChart)
 


### PR DESCRIPTION
Closes #271

## Summary

Adds a `space` knob to the GE-landscape API so users can view the model's **predicted functional score as a function of latent phenotype**, alongside the existing **fitness-space** view (the shared sigmoid `g(φ)`).

```python
model.plot_ge_landscape(space="fitness")     # default — unchanged
model.plot_ge_landscape(space="func_score")  # new per-condition func-score curves
```

`space` threads through all three layers: `Model.plot_ge_landscape` → `Model.get_ge_landscape_df` (all model math) → `multidms.plot.ge_landscape` (pure renderer).

**What each space produces:**

| | `space="fitness"` (default) | `space="func_score"` (new) |
|---|---|---|
| Scatter y default | `measured_fitness` | `func_score` (measured) |
| Curve df | wide: `predicted_latent`, `ge_curve_value` | long: `condition`, `predicted_latent`, `func_score_curve_value` |
| # curves | 1 shared grey `g(φ)` | one per condition, `α_c·(g(φ) − g(φ_wt,c))`, colored to match points |
| y-axis | Fitness | Functional score |

Because `α` and `φ_wt` are per-condition, the func-score view is **one curve per condition**, each anchored at `(φ_wt, 0)`, over one shared global φ grid so the curves are directly comparable.

The marimo dashboard's **GE Landscape tab** now renders **both views stacked** (fitness on top, func_score below) for the selected fit.

## Changes

- **`multidms/model.py`** — `get_ge_landscape_df(space=...)` gains a validated `space` param + a func_score branch that builds the long-form per-condition curve df (α/`g_wt` handled with the same scalar/dict pattern as `get_variants_df`). `plot_ge_landscape(space=...)` forwards `space` to both data-prep and renderer.
- **`multidms/plot.py`** — `ge_landscape(space=...)` gains the param; `fitness_col` becomes a sentinel (`None`) resolved per-space; a func_score curve layer draws one condition-colored line per condition. Fitness mode is unchanged. Renderer stays pure (reads columns only, no model math).
- **`experiments/dashboard.py`** — GE Landscape cell renders both views via nested `mo.vstack`.
- **`tests/test_model.py`** — new tests (see below).

## Testing

- ✅ `tests/test_model.py` — 76 passed (12 pre-existing GE tests + new ones).
- ✅ Module doctests (`model.py`, `plot.py`) — 3 passed.
- ✅ `ruff check .` clean; `black --check` clean.

New tests:
- **Regression** — `space="fitness"` output byte-for-byte identical to the default call (`pd.testing.assert_frame_equal`).
- **Schema** — func_score returns long-form df with the right columns and `n_conditions × n_curve_points` rows.
- **Reconstruction** (the load-bearing correctness test) — evaluating `α·(g(φ_i) − g(φ_wt))` at each variant's own latent reproduces its `predicted_func_score` to 1e-5. Catches a wrong-α or wrong-`g_wt` bug that the weak "anchor at 0" test cannot.
- **Per-condition differentiation** — conditions with different `φ_wt` produce non-identical curves.
- **Monotonicity** — each curve is monotonically increasing (Sigmoid, α>0).
- **Custom grid**, **invalid-space `ValueError`**, and **plot smoke tests** (renderer + convenience wrapper, the latter inspecting the serialized spec's bound datasets to confirm `func_score_curve_value` is actually plotted).

> **Note on the full-suite run:** `pytest -m "slow or not slow"` shows `246 passed, 1 failed`. The one failure — `test_convergence_lab_harness.py::test_load_rep_data_builds_two_reps` — is **pre-existing and unrelated** to this PR: it exists on `main`, touches none of the four files changed here, and fails only because a gitignored real-data CSV (`experiments/scv2-spike/results-prod-.../training_functional_scores.csv`) is absent locally. It is normally skipped by the repo's `-m 'not slow'` default.

## Deviations from spec

- **Strengthened the func_score convenience test beyond the spec.** The spec proposed a bare `isinstance(chart, alt.LayerChart)` smoke test for `plot_ge_landscape(space="func_score")`. That passes even if the wrapper feeds a fitness-space curve df to the func_score renderer (Altair binds field names lazily and doesn't validate columns). The test now inspects the serialized spec's shared `datasets` to confirm a `func_score_curve_value` column is actually bound — verified to fail against the buggy df and pass against the correct one. Same intent as the spec, materially stronger guard.
- **`plot_ge_landscape` `space` passthrough is explicit, not via `**kwargs`.** Task 4 sets `get_ge_landscape_df(space=space)` and `ge_landscape(space=space, **kwargs)` explicitly. (During implementation the `**kwargs`-only path silently produced a mismatched curve df / renderer space; the explicit passthrough is what the spec intended and fixes it.)
- Otherwise the implementation matches the spec: `space` knob through all three layers, one curve per condition on a shared global grid, `plot.py` stays a pure renderer, fitness mode byte-for-byte unchanged, dashboard both-views-stacked, sentinel `fitness_col=None`.

Yolo trail: spec gate ✓, plan gate ✓ — full log in _ignore/yolo/271.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

