### PR TITLE
convergence-lab: free (per-condition) α lowers Delta's functional-score floor (#273)

### DIFF
--- a/experiments/convergence-lab/README.md
+++ b/experiments/convergence-lab/README.md
@@ -67,6 +67,23 @@ directory run `pixi run dashboard` (it discovers `fit_collection.pkl` below cwd)
   keeps α·φ bounded — "large Σβ²" only signals an explosion when the fit *also*
   fails to converge (as at l2reg=0 in #256). The epic's downstream phases inherit
   the clip bound.
+- **A free (per-condition) α deepens Delta's functional-score floor toward the
+  true −3.5** (measured, #273, `cache=273-free-alpha`): sweeping
+  `share_alpha` True/False across `fusionreg [0, 4e-5, 1.6e-4, 6.4e-4]` at PR
+  270's exact fitting block (`warmstart=false`, `l2reg=0`, `recompute_scale=false`,
+  Sigmoid, inner blocks maxiter=10/maxls=10, outer tol=1e-5/maxiter=50). Delta's
+  predicted floor = `−α_Delta · sigmoid(φ_wt,Delta)` (the low asymptote of
+  `α·(g(φ)−g(φ_wt))` as φ→−∞). At the prod-strength `fusionreg=6.4e-4`, freeing α
+  lets Delta take its **own** α (5.2, decoupled from BA1's 17.8 / BA2's 14.4)
+  and drops Delta's floor from **−2.16 (shared) → −3.09 (free)** — most of the
+  way to the true −3.5, where the shared α is pinned by the other two conditions.
+  Counter-intuitively the deeper floor comes with a *smaller* Delta α: freeing α
+  lets the Delta latent push φ_wt more positive so `−α·sigmoid(φ_wt)` deepens.
+  The effect grows with fusion (floor gap free−shared: −0.15 at fusionreg=0,
+  −0.93 at 6.4e-4). BA1/BA2 floors barely move. All 16 fits hit maxiter=50
+  (0/16 converged, same as PR 270's 0/18 at tol=1e-6 — the looser tol=1e-5
+  didn't buy convergence), but obj_err is tiny (≤3e-4), so the α/floor numbers
+  are trustworthy while the binary flag is not.
 - **`recompute_scale=False`** (the fixed-scale objective normalizer) converges.
 - **`fit_models` parallelism — settled** (`diagnostics/parallelism_probe.py`):
   `n_processes=2` (the real spawn path) ran the full data-size × l2reg staircase
@@ -88,6 +105,11 @@ directory run `pixi run dashboard` (it discovers `fit_collection.pkl` below cwd)
 (Append one entry per harness run: date, cache name, config swept, what the
 fit collection showed — basin diagnostics and replicate correlation computed
 downstream from a ModelCollection — the conclusion, the next step.)
+
+- 2026-07-07 | cache=273-free-alpha | sweep: share_alpha [True, False] × fusionreg [0.0, 4e-5, 1.6e-4, 6.4e-4], 2 reps (16 fits), PR 270 fitting block verbatim (warmstart=False, recompute_scale=False, l2reg=0, Sigmoid, alpha_init=6, beta_clip [-10,10], inner ge/cal_kwargs maxiter=10/maxls=10/tol=1e-4) + 3 deltas from PR 270 (outer tol 1e-6→1e-5, 4-point fusionreg, share_alpha swept). Independent fitting (#273). Wall 718s at n_processes=13 (local, Apple M4 Max). Numbers computed inline from a ModelCollection over the frame (dashboard-only exploration; no committed analysis code). Delta floor = −α_Delta·sigmoid(φ_wt,Delta), the low asymptote of α·(g(φ)−g(φ_wt)) as φ→−∞ (analytic and model-GE-at-φ=−1e4 evaluations agreed to 0.0e0).
+  Delta α + floor (mean over reps), shared vs free, across fusionreg 0 / 4e-5 / 1.6e-4 / 6.4e-4: SHARED α → α 16.8/17.0/14.8/13.5, floor −5.08/−4.69/−3.22/−2.16. FREE α → Delta's own α 16.8/18.1/12.9/5.2 (decoupled from BA1 17.8 / BA2 14.4 at 6.4e-4), floor −5.24/−4.82/−3.45/−3.09. At the prod-strength fusionreg=6.4e-4 freeing α drops Delta's floor from −2.16 → −3.09 (gap −0.93), most of the way to the true −3.5 that the shared α (pinned by BA1/BA2) cannot reach. Effect grows with fusion (floor gap free−shared −0.15 at fr=0 → −0.93 at fr=6.4e-4); BA1/BA2 floors barely move. Counter-intuitively the deeper floor comes with a *smaller* Delta α — freeing α lets the Delta latent push φ_wt more positive so −α·sigmoid(φ_wt) deepens.
+  Convergence: 0/16 converged (all hit maxiter=50), same as PR 270's 0/18 at tol=1e-6 — the looser tol=1e-5 did NOT buy convergence. But obj_err ≤3e-4 (range 5.9e-5–3.0e-4), so the α/floor numbers are trustworthy; the binary flag is not (same maxiter-truncation pattern as the l2-fusion / smoke runs).
+  Conclusion: CONFIRMS the PR 270 hypothesis — the single shared α is the reason Delta under-fits its low tail. A per-condition α lets Delta decouple and pull its floor toward the true −3.5, with the effect concentrated at strong fusion (exactly where PR 270 saw the −2.5 shortfall). Standing findings updated (new free-α floor finding). Next: confirm on the full scv2-spike pipeline (share_alpha=false prod run) that the deeper floor holds against held-out data and does not reintroduce the per-condition sigmoid degeneracy the shared-α default guards against; optionally pair with a small l2reg>0 (the β-explosion tamer) since this run sits in the l2reg=0 regime.
 
 - 2026-07-06 | cache=beta-control-clip + beta-control-l2 | Phase 1 (#263), EPIC #262. sweep: arm {clip[-10,10], l2reg=1e-4} × fusionreg [0.0, 4e-5, 6.4e-4], 2 reps (12 fits). Base regime: cold-start (warmstart=false), recompute_scale=false, share_alpha=true, Sigmoid, maxiter=100 (ceiling), tol=1e-6. Independent fitting. Local (M4 Max). Downstream from diagnostics/beta_control_report.py.
   Basin diagnostics (Σβ², α per cell): clip arm → Σβ² 110,597–180,962, α 2.96–3.39, **all 6 converged=True** (final_obj_err 6e-8–9e-7). l2 arm → Σβ² 221–300, α 52.5–58.8, all 6 converged=False (final_obj_err 8e-5 at fusionreg=0 rising to ~2.8e-4 at 6.4e-4). This is the α/β see-saw in the open: clip caps φ so α stays low (~3) and the fit converges cleanly despite a large Σβ²; l2 collapses β and drives α to ~55, and it never reaches tol=1e-6. Large clip-Σβ² is NOT an explosion — α·φ is bounded by the clip and the objective converges (contrast #256's l2reg=0 Σβ²~16–19k which did NOT converge to tol).

--- a/experiments/convergence-lab/grids/free-alpha.yaml
+++ b/experiments/convergence-lab/grids/free-alpha.yaml
@@ -1,0 +1,25 @@
+# free-alpha grid (#273) — does a per-condition α (share_alpha=false) lower
+# Delta's functional-score floor toward the true −3.5 that a shared α can't
+# reach? A smaller, local version of the PR 270 recompute-scale run.
+# 2 share_alpha × 4 fusionreg × 2 reps = 16 fits. Diagnostic, NOT tuning.
+sweep:
+  share_alpha: [true, false]                    # the toggle under test
+  fusionreg: [0.0, 4.0e-5, 1.6e-4, 6.4e-4]      # reduced from PR 270's 9-point grid
+fixed:
+  # --- PR 270 config_recompute_false.yaml fitting block, verbatim ---
+  warmstart: false
+  recompute_scale: false
+  ge_type: Sigmoid
+  l2reg: 0.0
+  beta0_ridge: 0.0
+  scale_fusion_by_n: false
+  alpha_init: 6.0
+  beta0_init: {Omicron_BA1: 0.0, Delta: 0.0, Omicron_BA2: 0.0}
+  beta_clip_range: [-10, 10]
+  loss_kwargs: {δ: 1.0}
+  maxiter: 50                                   # outer block cap (PR 270)
+  # --- deltas from PR 270 ---
+  tol: 1.0e-5                                   # outer tol LOOSENED from PR 270's 1e-6
+  ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+  cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+replicates: [1, 2]


### PR DESCRIPTION
Closes #273

## TL;DR — the hypothesis holds

PR 270 (the scv2-spike recompute-scale run) left Delta under-fitting its low
tail: Delta's predicted functional-score floor bottomed at **~−2.5** while the
true Delta scores reach **−3.5**. The suspicion was that the single **shared** α
scalar across all three conditions cannot stretch Delta's sigmoid down far
enough. This PR tests that in the convergence-lab harness with a tight 16-fit
grid that toggles `share_alpha`.

**Result: freeing α confirms the hypothesis.** At the prod-strength
`fusionreg=6.4e-4`, a per-condition α lets Delta decouple to its own α and pulls
Delta's floor from **−2.16 → −3.09** — most of the way to the true −3.5 that the
shared α (pinned by the other two conditions) cannot reach.

## What changed

- **New grid `experiments/convergence-lab/grids/free-alpha.yaml`** — a 16-cell
  diagnostic: `share_alpha [True, False] × fusionreg [0, 4e-5, 1.6e-4, 6.4e-4] ×
  2 reps`. The `fixed:` block is PR 270's `config_recompute_false.yaml` fitting
  block **verbatim**, with three deltas:

  | Setting | PR 270 | This grid |
  |---|---|---|
  | outer `tol` | `1e-6` | **`1e-5`** (looser) |
  | `fusionreg` | 9-point `[0 … 6.4e-4]` | **4-point** `[0, 4e-5, 1.6e-4, 6.4e-4]` |
  | `share_alpha` | fixed `true` | **swept** `[true, false]` |

- **`experiments/convergence-lab/README.md`** — new Run log entry (2026-07-07,
  `cache=273-free-alpha`) and a new Standing finding for the free-α floor effect.

No harness code changes — `share_alpha` was already a sweepable `VALID_KWARGS`
key and the harness already owns the constant spike data. The whole experiment
is one YAML grid + the analysis-at-PR-time below.

## The finding (computed inline; dashboard-only exploration otherwise)

The harness computes no metrics, so the headline numbers were produced in a
throwaway session over the pkl. **Delta's floor** = the low asymptote of
`α_Delta·(g(φ) − g(φ_wt))` as φ → −∞. For the Sigmoid GE, `g(−∞)=0`, so
`floor = −α_Delta · sigmoid(φ_wt,Delta)`. Computed two ways — the analytic
`−α·g(φ_wt)` and the model's own `global_epistasis` evaluated at φ=−1e4 — which
**agreed to 0.0e0**.

### Delta: α and floor, mean over the 2 replicates

| fusionreg | shared α | shared floor | free Delta α | free floor | Δfloor (free−shared) |
|---|---|---|---|---|---|
| 0.0 | 16.81 | −5.08 | 16.81 | −5.24 | −0.15 |
| 4.0e-5 | 17.01 | −4.69 | 18.07 | −4.82 | −0.14 |
| 1.6e-4 | 14.76 | −3.22 | 12.85 | −3.45 | −0.23 |
| **6.4e-4** | **13.47** | **−2.16** | **5.23** | **−3.09** | **−0.93** |

**Headline (−2.5 → −3.5 question): yes.** At the strongest fusion — exactly
where PR 270 saw the −2.5 shortfall — freeing α deepens Delta's floor from
−2.16 to −3.09, closing most of the gap to −3.5. The effect **grows with
fusion** (Δfloor −0.15 at `fusionreg=0` → −0.93 at `6.4e-4`).

### Why it works — Delta's α decouples

With a free α, Delta takes its **own** scale, no longer averaged with the other
two conditions. Per-condition α at `fusionreg=6.4e-4` (mean over reps):

| condition | shared α | free α |
|---|---|---|
| Delta | 13.47 | **5.23** |
| Omicron_BA1 | 13.47 | 17.75 |
| Omicron_BA2 | 13.47 | 14.44 |

BA1/BA2 floors barely move; Delta's does all the work. Counter-intuitively the
deeper floor comes with a *smaller* Delta α: freeing α lets the Delta latent
push `φ_wt` more positive, so `−α·sigmoid(φ_wt)` deepens even as α shrinks.

## Convergence note

**0/16 fits converged** — every fit hit the `maxiter=50` outer cap, split evenly
(0/8 shared, 0/8 free). This matches PR 270's 0/18 at `tol=1e-6`: the looser
`tol=1e-5` did **not** buy convergence. But the final outer objective error is
tiny (range **5.9e-5 – 3.0e-4**), the same maxiter-truncation pattern the lab has
seen on the smoke and l2-fusion runs — the α/floor numbers are trustworthy; the
binary `converged` flag is not.

## Standing-finding caveat

This grid runs in the l2reg=0 / `warmstart=false` regime — the same regime that
produced the −2.5 floor, and the one the lab's **α/β see-saw degeneracy**
standing finding describes (β explodes, α compensates). The floor result is
robust within this regime, but it has **not** been checked against held-out data
or paired with the small `l2reg>0` that tames the β-explosion. Freeing α also
relaxes the very guard the shared-α default exists for (preventing per-condition
sigmoid degeneracy). Treat this as a confirmed diagnostic, not a settled prod
recommendation — see the "Next" in the Run log.

## How to reproduce

From `experiments/convergence-lab/`:

```bash
# 1. Fit the 16-cell grid (writes results/273-free-alpha/fit_collection.pkl)
pixi run python harness.py --config grids/free-alpha.yaml --cache 273-free-alpha

# 2. Explore interactively (discovers the pkl below cwd)
pixi run dashboard
```

The pkl (`results/273-free-alpha/fit_collection.pkl`, 16 rows) is gitignored —
regenerated on demand by step 1. Wall time ~12 min locally (Apple M4 Max,
`n_processes=13`).

## Deviations from spec

- **Data-CSV symlink (mechanical, not a spec change).** The harness reads a
  gitignored spike-pipeline results file
  (`experiments/scv2-spike/results-prod-235-times-seen-threshold/training_functional_scores.csv`)
  that does not exist in a fresh worktree. I symlinked the canonical clone's
  copy into the worktree — the same reuse-not-regenerate pattern the workflow
  uses for the pixi env. It is gitignored, so nothing extra is committed, and it
  does not touch the experiment definition. The spec assumed "the harness already
  owns the constant spike data"; that holds in the canonical clone but needs the
  symlink in an isolated worktree.
- Everything else matches the spec exactly: 16-cell grid, PR 270 block verbatim +
  the 3 deltas, local run, pkl named `273-free-alpha`, inline finding, reproduce
  commands, convergence note, caveat, README Run log + Standing-findings update.

Yolo trail: spec gate ✓, plan gate ✓ — full log in _ignore/yolo/273.log
