### PR TITLE
Add softplus output-activation floor (default-off) + scv2-spike softplus×free-α 2×2

### DIFF
--- a/experiments/convergence-lab/README.md
+++ b/experiments/convergence-lab/README.md
@@ -84,6 +84,19 @@ directory run `pixi run dashboard` (it discovers `fit_collection.pkl` below cwd)
   (0/16 converged, same as PR 270's 0/18 at tol=1e-6 — the looser tol=1e-5
   didn't buy convergence), but obj_err is tiny (≤3e-4), so the α/floor numbers
   are trustworthy while the binary flag is not.
+- **Softplus output floor caps the weak-fusion runaway but is near-inert at
+  prod fusion** (measured, #277, `cache=277-softplus-floor`): with an explicit
+  `output_floor=-3.5` softplus (hinge 0.1) fixed on and share_alpha=true, Delta's
+  *pre-activation* floor `−α·sigmoid(φ_wt)` runs to −15…−17 at weak fusion
+  (0…1.6e-4) and the softplus hard-truncates it to exactly −3.5; at prod fusion
+  (6.4e-4) the raw floor only reaches −2.96 so the softplus barely moves it
+  (−2.94). The softplus and **free-α (#274) attack opposite regimes and are
+  complementary, not redundant**: free-α *deepens* the under-shooting prod floor
+  (−2.16→−3.09) by decoupling Delta's α; the softplus *caps* the over-shooting
+  weak-fusion floor and is a near-no-op at prod. The softplus is a **blunt clip**
+  (it floors all three conditions), so it does not, on its own, lift the
+  prod-fusion floor toward −3.5 the way free-α does. Ships **default-off**
+  (`output_floor=None`); turning it on is a per-experiment choice.
 - **`recompute_scale=False`** (the fixed-scale objective normalizer) converges.
 - **`fit_models` parallelism — settled** (`diagnostics/parallelism_probe.py`):
   `n_processes=2` (the real spawn path) ran the full data-size × l2reg staircase
@@ -116,6 +129,16 @@ downstream from a ModelCollection — the conclusion, the next step.)
   maxiter each needs (outer iters to cross tol=1e-6 / 1e-4): clip → 1e-6 at {fusionreg=0: 60,26 · 4e-5: 30,39 · 6.4e-4: 55,13}, 1e-4 at 6–8 iters everywhere (4/6 of the 1e-6 crossings land in the epic's 20–50 band, the other two at 13 and 60). l2 → 1e-6 NEVER crossed (sentinel 101 on all 6); 1e-4 crossed only at fusionreg=0 (iter 88/89) and never at fusionreg≥4e-5 (101). The clip arm is the ONLY arm that reaches tol=1e-6, and it does so cheaply.
   Replicate-shift Pearson r (shift_* rows, per arm, across fusionreg 0/4e-5/6.4e-4): clip → shift_Delta 0.49/0.46/0.59, shift_Omicron_BA2 0.38/0.56/0.81. l2 → shift_Delta 0.49/0.44/0.49, shift_Omicron_BA2 0.33/0.36/0.66. Strong fusion RESCUES the data-poor shift_Omicron_BA2 under both arms, but clip lifts it higher (0.81 vs 0.66) and also lifts shift_Delta at prod-max fusion (0.59 vs 0.49) — clip dominates the reproducibility criterion at every fusion strength.
   Conclusion (tri-criteria — speed × basin health × rising reproducibility): **clip[-10,10] wins, decisively and on all three axes.** Speed: clip is the only arm that converges to tol=1e-6 (l2 never does), landing 4/6 fits in the 20–50 band. Basin health: clip keeps α~3 (healthy) while l2's α blows up to ~55 (the see-saw's collapse end) — the low Σβ² of l2 is the symptom, not the cure. Reproducibility: clip's strong-fusion shift_Omicron_BA2 r reaches 0.81 vs l2's 0.66. This overturns the gauge argument's tie-break expectation (it predicted clip would win, but on a *healthier Σβ²* — instead clip wins with a *large* Σβ² held harmless by the hard φ-cap). **The epic's downstream phases (#264 recompute_scale, #265 warmstart) inherit `beta_clip_range=[-10,10]` as the β-bound.** Next: Phase 2 / #264 — vary recompute_scale at the clip bound.
+
+- 2026-07-07 | cache=277-softplus-floor | sweep: fusionreg [0.0, 4e-5, 1.6e-4, 6.4e-4] × 2 reps (8 fits), output_floor=-3.5 (softplus, hinge=0.1) FIXED ON for all cells, share_alpha=true, warmstart=false, recompute_scale=false, Sigmoid, alpha_init=6.0, beta_clip_range=[-10,10], maxiter=50, tol=1e-5. #274's free-alpha.yaml fixed block VERBATIM + the two changes (floor on, share_alpha fixed true). Wall 307.5s at n_processes=8 (local, Apple M4 Max), 8 fit / 0 failed. The A/B is CROSS-PR: this softplus-ON run vs #274's shared-α (softplus-OFF) column.
+  Delta floor (mean over 2 reps), computed two ways (analytic `t(−α·sigmoid(φ_wt))` and model composition at φ=−1e4) — agreed to 0.0e0:
+    | fusionreg | #274 OFF | this ON | pre-activation floor | clamped? |
+    |---|---|---|---|---|
+    | 0.0 | −5.08 | −3.50 | −15.74 | yes |
+    | 4.0e-5 | −4.69 | −3.50 | −15.75 | yes |
+    | 1.6e-4 | −3.22 | −3.50 | −16.43 | yes |
+    | 6.4e-4 | −2.16 | −2.94 | −2.96 | no |
+  Conclusion: the softplus floor and free-α (#274) attack OPPOSITE regimes. At weak fusion (0…1.6e-4) the shared-α sigmoid drives Delta's raw pre-activation floor to −15…−17 — far past the biological −3.5 — and the softplus HARD-TRUNCATES it up to exactly −3.5 (the assay detection floor). At prod fusion (6.4e-4) the raw floor only reaches −2.96, so the softplus is nearly a NO-OP (−2.94); the −2.94-vs-#274's-−2.16 gap there is mostly an α-landing artifact between two separate fits, not the hinge biting. Unlike free-α (which DEEPENS the under-shooting prod floor −2.16→−3.09 by decoupling Delta's α), the softplus does NOT lift the prod floor toward −3.5 on its own; it caps the over-shooting weak-fusion floor and floors ALL conditions bluntly (not just Delta). Complementary, not redundant. Convergence: pkl carries no converged/final_obj_err column (computed downstream); #274 saw 0/16 at these tols; all 8 softplus fits completed, adding the floor introduced no failures. Next: if a floored prod recommendation is wanted, pair the softplus with free-α or l2reg>0 (the softplus alone does not fix the prod under-fit); counts-path floor is deferred to a separate stub.
 
 - 2026-06-30 | cache=l2-fusion | sweep: l2reg [0.0, 1e-4, 3e-4] × fusionreg [0.0, 4e-5, 6.4e-4], 2 reps (18 fits), warmstart=True, recompute_scale=False, share_alpha=True, Sigmoid, maxiter=25. Independent fitting (#256). Wall 1138s at n_processes=4 (local, Apple M4 Max). Downstream numbers from diagnostics/l2_fusion_report.py.
   Basin diagnostics (Σβ², α per cell): at l2reg=0.0 → Σβ² 16,181–19,222, α 5.9–8.2 (β EXPLODED at EVERY fusionreg, incl. 6.4e-4). l2reg=1e-4 → Σβ² 554–841, α 19.5–24.6 (β tamed ~25× into the healthy 350–1400 band, holds across all fusion). l2reg=3e-4 → Σβ² 188–298, α 30.5–40.4 (β tamed further but α climbing toward the see-saw collapse end). All 18 converged=False, but final_obj_err is tiny (4e-6 at l2reg=0 to ~7e-4 at l2reg>0) — maxiter=25 truncation, not a pathology; β-magnitude and r are trustworthy, the binary flag is not.

--- a/experiments/convergence-lab/README.md
+++ b/experiments/convergence-lab/README.md
@@ -84,19 +84,25 @@ directory run `pixi run dashboard` (it discovers `fit_collection.pkl` below cwd)
   (0/16 converged, same as PR 270's 0/18 at tol=1e-6 — the looser tol=1e-5
   didn't buy convergence), but obj_err is tiny (≤3e-4), so the α/floor numbers
   are trustworthy while the binary flag is not.
-- **Softplus output floor caps the weak-fusion runaway but is near-inert at
-  prod fusion** (measured, #277, `cache=277-softplus-floor`): with an explicit
-  `output_floor=-3.5` softplus (hinge 0.1) fixed on and share_alpha=true, Delta's
-  *pre-activation* floor `−α·sigmoid(φ_wt)` runs to −15…−17 at weak fusion
-  (0…1.6e-4) and the softplus hard-truncates it to exactly −3.5; at prod fusion
-  (6.4e-4) the raw floor only reaches −2.96 so the softplus barely moves it
-  (−2.94). The softplus and **free-α (#274) attack opposite regimes and are
-  complementary, not redundant**: free-α *deepens* the under-shooting prod floor
-  (−2.16→−3.09) by decoupling Delta's α; the softplus *caps* the over-shooting
-  weak-fusion floor and is a near-no-op at prod. The softplus is a **blunt clip**
-  (it floors all three conditions), so it does not, on its own, lift the
-  prod-fusion floor toward −3.5 the way free-α does. Ships **default-off**
-  (`output_floor=None`); turning it on is a per-experiment choice.
+- **Softplus output floor perturbs the fit everywhere; hard-truncates the
+  weak-fusion runaway but relies on an α shift at prod** (measured, #277, matched
+  in-harness A/B, `cache=277-softplus-floor` ON vs `277-softplus-floor-off` OFF):
+  with `output_floor=-3.5` (hinge 0.1) fixed on and share_alpha=true, the fitted
+  shared α lands a consistent **+3.8…+4.5 higher ON than OFF** across all four
+  fusion cells (+29% at prod, 13.47→17.36) — the floor is inside `predict_score`
+  so it changes the optimization at every strength, not just the deep-tail cells.
+  Two regimes: at weak fusion (0…1.6e-4) the shared-α sigmoid drives Delta's
+  *pre-activation* floor to −15…−17 (past the biological −3.5) and the softplus
+  **hard-truncates it to exactly −3.5**; at prod fusion (6.4e-4) the raw floor only
+  reaches −2.96 so the hinge itself clips almost nothing (−2.96→−2.94), but the
+  OFF→ON floor still deepens −2.16→−2.94 driven by the higher fitted α, not the
+  hinge. **Complementary with free-α (#274), opposite regimes**: free-α *deepens*
+  the under-shooting prod floor (−2.16→−3.09) by selectively decoupling Delta's α;
+  the softplus is a **blunt clip** (floors all three conditions) that mainly caps
+  the over-shooting weak-fusion tail and does **not**, on its own, pull the prod
+  floor to −3.5. Ships **default-off** (`output_floor=None`); turning it on is a
+  per-experiment choice. The OFF control reproduced #274's separately-fit column
+  exactly, confirming the fit is deterministic and the A/B fair.
 - **`recompute_scale=False`** (the fixed-scale objective normalizer) converges.
 - **`fit_models` parallelism — settled** (`diagnostics/parallelism_probe.py`):
   `n_processes=2` (the real spawn path) ran the full data-size × l2reg staircase
@@ -130,15 +136,15 @@ downstream from a ModelCollection — the conclusion, the next step.)
   Replicate-shift Pearson r (shift_* rows, per arm, across fusionreg 0/4e-5/6.4e-4): clip → shift_Delta 0.49/0.46/0.59, shift_Omicron_BA2 0.38/0.56/0.81. l2 → shift_Delta 0.49/0.44/0.49, shift_Omicron_BA2 0.33/0.36/0.66. Strong fusion RESCUES the data-poor shift_Omicron_BA2 under both arms, but clip lifts it higher (0.81 vs 0.66) and also lifts shift_Delta at prod-max fusion (0.59 vs 0.49) — clip dominates the reproducibility criterion at every fusion strength.
   Conclusion (tri-criteria — speed × basin health × rising reproducibility): **clip[-10,10] wins, decisively and on all three axes.** Speed: clip is the only arm that converges to tol=1e-6 (l2 never does), landing 4/6 fits in the 20–50 band. Basin health: clip keeps α~3 (healthy) while l2's α blows up to ~55 (the see-saw's collapse end) — the low Σβ² of l2 is the symptom, not the cure. Reproducibility: clip's strong-fusion shift_Omicron_BA2 r reaches 0.81 vs l2's 0.66. This overturns the gauge argument's tie-break expectation (it predicted clip would win, but on a *healthier Σβ²* — instead clip wins with a *large* Σβ² held harmless by the hard φ-cap). **The epic's downstream phases (#264 recompute_scale, #265 warmstart) inherit `beta_clip_range=[-10,10]` as the β-bound.** Next: Phase 2 / #264 — vary recompute_scale at the clip bound.
 
-- 2026-07-07 | cache=277-softplus-floor | sweep: fusionreg [0.0, 4e-5, 1.6e-4, 6.4e-4] × 2 reps (8 fits), output_floor=-3.5 (softplus, hinge=0.1) FIXED ON for all cells, share_alpha=true, warmstart=false, recompute_scale=false, Sigmoid, alpha_init=6.0, beta_clip_range=[-10,10], maxiter=50, tol=1e-5. #274's free-alpha.yaml fixed block VERBATIM + the two changes (floor on, share_alpha fixed true). Wall 307.5s at n_processes=8 (local, Apple M4 Max), 8 fit / 0 failed. The A/B is CROSS-PR: this softplus-ON run vs #274's shared-α (softplus-OFF) column.
-  Delta floor (mean over 2 reps), computed two ways (analytic `t(−α·sigmoid(φ_wt))` and model composition at φ=−1e4) — agreed to 0.0e0:
-    | fusionreg | #274 OFF | this ON | pre-activation floor | clamped? |
-    |---|---|---|---|---|
-    | 0.0 | −5.08 | −3.50 | −15.74 | yes |
-    | 4.0e-5 | −4.69 | −3.50 | −15.75 | yes |
-    | 1.6e-4 | −3.22 | −3.50 | −16.43 | yes |
-    | 6.4e-4 | −2.16 | −2.94 | −2.96 | no |
-  Conclusion: the softplus floor and free-α (#274) attack OPPOSITE regimes. At weak fusion (0…1.6e-4) the shared-α sigmoid drives Delta's raw pre-activation floor to −15…−17 — far past the biological −3.5 — and the softplus HARD-TRUNCATES it up to exactly −3.5 (the assay detection floor). At prod fusion (6.4e-4) the raw floor only reaches −2.96, so the softplus is nearly a NO-OP (−2.94); the −2.94-vs-#274's-−2.16 gap there is mostly an α-landing artifact between two separate fits, not the hinge biting. Unlike free-α (which DEEPENS the under-shooting prod floor −2.16→−3.09 by decoupling Delta's α), the softplus does NOT lift the prod floor toward −3.5 on its own; it caps the over-shooting weak-fusion floor and floors ALL conditions bluntly (not just Delta). Complementary, not redundant. Convergence: pkl carries no converged/final_obj_err column (computed downstream); #274 saw 0/16 at these tols; all 8 softplus fits completed, adding the floor introduced no failures. Next: if a floored prod recommendation is wanted, pair the softplus with free-α or l2reg>0 (the softplus alone does not fix the prod under-fit); counts-path floor is deferred to a separate stub.
+- 2026-07-07 | cache=277-softplus-floor (ON) + 277-softplus-floor-off (OFF control) | MATCHED in-harness A/B: same 8-cell grid fit twice — sweep fusionreg [0.0, 4e-5, 1.6e-4, 6.4e-4] × 2 reps, share_alpha=true, warmstart=false, recompute_scale=false, Sigmoid, alpha_init=6.0, beta_clip_range=[-10,10], maxiter=50, tol=1e-5 (#274's free-alpha.yaml fixed block VERBATIM) — once with output_floor=-3.5 (softplus, hinge=0.1), once with output_floor=null, so the floor is the ONLY difference. 16 fits, 0 failed, ~307s + ~326s at n_processes=8 (local, Apple M4 Max). The OFF control reproduces #274's separately-fit shared-α column to the last decimal (floor −5.08/−4.69/−3.22/−2.16, α 16.81/17.01/14.76/13.47), validating both the fit determinism and #274's cross-PR baseline.
+  Delta floor + fitted shared α (mean over 2 reps); floor computed two ways (analytic `t(−α·sigmoid(φ_wt))` and model composition at φ=−1e4) — agreed to 0.0e0:
+    | fusionreg | OFF floor | ON floor | Δfloor | OFF α | ON α | Δα | ON pre-act | clamped? |
+    |---|---|---|---|---|---|---|---|---|
+    | 0.0 | −5.08 | −3.50 | +1.58 | 16.81 | 20.61 | +3.80 | −15.74 | yes |
+    | 4.0e-5 | −4.69 | −3.50 | +1.19 | 17.01 | 21.34 | +4.32 | −15.75 | yes |
+    | 1.6e-4 | −3.22 | −3.50 | −0.28 | 14.76 | 19.24 | +4.48 | −16.43 | yes |
+    | 6.4e-4 | −2.16 | −2.94 | −0.79 | 13.47 | 17.36 | +3.90 | −2.96 | no |
+  Conclusion: the softplus perturbs the FIT at every fusion strength — fitted shared α is a consistent +3.8…+4.5 higher ON than OFF (+29% at prod), and because the floor is inside predict_score (which the loss uses) this is a real optimization effect, not fit-to-fit noise. Two regimes: at weak fusion (0…1.6e-4) the shared-α sigmoid drives Delta's raw pre-activation floor to −15…−17 (far past the biological −3.5) and the softplus HARD-TRUNCATES it to exactly −3.5 (the assay detection floor); at prod fusion (6.4e-4) the raw floor only reaches −2.96 so the hinge itself clips almost nothing (−2.96→−2.94), but the OFF→ON floor still deepens −2.16→−2.94 driven by the genuinely higher fitted α the floor induced, not by the hinge biting. vs #274 free-α (which DEEPENS the under-shooting prod floor −2.16→−3.09 by selectively decoupling Delta's α): the softplus is a BLUNT clip that floors all three conditions and mainly bites the over-shooting weak-fusion tail — it does NOT pull the prod floor to −3.5 on its own. Complementary, opposite regimes. Convergence: pkl carries no converged/final_obj_err column (computed downstream); #274 saw 0/16 at these tols; all 16 fits completed, floor introduced no failures. Next: for a floored prod recommendation, pair the softplus with free-α or l2reg>0 (softplus alone does not fix the prod under-fit); counts-path floor deferred to a separate stub.
 
 - 2026-06-30 | cache=l2-fusion | sweep: l2reg [0.0, 1e-4, 3e-4] × fusionreg [0.0, 4e-5, 6.4e-4], 2 reps (18 fits), warmstart=True, recompute_scale=False, share_alpha=True, Sigmoid, maxiter=25. Independent fitting (#256). Wall 1138s at n_processes=4 (local, Apple M4 Max). Downstream numbers from diagnostics/l2_fusion_report.py.
   Basin diagnostics (Σβ², α per cell): at l2reg=0.0 → Σβ² 16,181–19,222, α 5.9–8.2 (β EXPLODED at EVERY fusionreg, incl. 6.4e-4). l2reg=1e-4 → Σβ² 554–841, α 19.5–24.6 (β tamed ~25× into the healthy 350–1400 band, holds across all fusion). l2reg=3e-4 → Σβ² 188–298, α 30.5–40.4 (β tamed further but α climbing toward the see-saw collapse end). All 18 converged=False, but final_obj_err is tiny (4e-6 at l2reg=0 to ~7e-4 at l2reg>0) — maxiter=25 truncation, not a pathology; β-magnitude and r are trustworthy, the binary flag is not.

--- a/experiments/convergence-lab/README.md
+++ b/experiments/convergence-lab/README.md
@@ -84,25 +84,37 @@ directory run `pixi run dashboard` (it discovers `fit_collection.pkl` below cwd)
   (0/16 converged, same as PR 270's 0/18 at tol=1e-6 — the looser tol=1e-5
   didn't buy convergence), but obj_err is tiny (≤3e-4), so the α/floor numbers
   are trustworthy while the binary flag is not.
-- **Softplus output floor perturbs the fit everywhere; hard-truncates the
-  weak-fusion runaway but relies on an α shift at prod** (measured, #277, matched
-  in-harness A/B, `cache=277-softplus-floor` ON vs `277-softplus-floor-off` OFF):
-  with `output_floor=-3.5` (hinge 0.1) fixed on and share_alpha=true, the fitted
-  shared α lands a consistent **+3.8…+4.5 higher ON than OFF** across all four
-  fusion cells (+29% at prod, 13.47→17.36) — the floor is inside `predict_score`
-  so it changes the optimization at every strength, not just the deep-tail cells.
-  Two regimes: at weak fusion (0…1.6e-4) the shared-α sigmoid drives Delta's
-  *pre-activation* floor to −15…−17 (past the biological −3.5) and the softplus
-  **hard-truncates it to exactly −3.5**; at prod fusion (6.4e-4) the raw floor only
-  reaches −2.96 so the hinge itself clips almost nothing (−2.96→−2.94), but the
-  OFF→ON floor still deepens −2.16→−2.94 driven by the higher fitted α, not the
-  hinge. **Complementary with free-α (#274), opposite regimes**: free-α *deepens*
-  the under-shooting prod floor (−2.16→−3.09) by selectively decoupling Delta's α;
-  the softplus is a **blunt clip** (floors all three conditions) that mainly caps
-  the over-shooting weak-fusion tail and does **not**, on its own, pull the prod
-  floor to −3.5. Ships **default-off** (`output_floor=None`); turning it on is a
-  per-experiment choice. The OFF control reproduced #274's separately-fit column
-  exactly, confirming the fit is deterministic and the A/B fair.
+- **Softplus floor × free-α is a complementary 2×2 — only BOTH together floor the
+  prod tail to the biological −3.5** (measured, #277, full in-harness 2×2:
+  `cache=277-softplus-floor{,-off}` share_alpha=true, `…-freealpha` /
+  `…-off-freealpha` share_alpha=false; `output_floor=-3.5` hinge 0.1 vs null;
+  4 fusion × 2 reps each = 32 fits, 0 failed; Delta floor computed two ways —
+  analytic `t(−α·g(φ_wt))` and model composition at φ=−1e4 — agreed to 0.0e0 on
+  all 32). Delta floor (mean over 2 reps):
+  ```
+  fusionreg    free-OFF  free-ON   shared-OFF  shared-ON
+  0.0           -5.24    -3.50      -5.09       -3.50
+  4e-5          -4.82    -3.50      -4.69       -3.50
+  1.6e-4        -3.45    -3.50      -3.22       -3.50
+  6.4e-4(prod)  -3.09    -3.50      -2.16       -2.95
+  ```
+  The **softplus is a blunt clip**: it hard-truncates the *pre-activation* floor to
+  −3.5 wherever that raw floor overshoots the hinge. At weak fusion (0…1.6e-4) both
+  α regimes drive Delta's pre-activation floor to −11…−16 (far past −3.5), so ON
+  pins every one of those cells to exactly −3.5. The floor is inside `predict_score`
+  (which the loss uses), so turning it on also perturbs the fit everywhere — fitted
+  α lands consistently higher ON than OFF in both regimes. **Free-α** does the
+  opposite thing: it *deepens the pre-activation floor selectively* by letting
+  Delta's own α decouple (Delta α at prod: shared 13.47 → free **5.23** OFF), which
+  by itself takes the OFF prod floor −2.16 → −3.09. **The prod cell is the whole
+  point:** softplus-alone gets −2.16 → −2.95 (α-driven, raw floor only −2.96 so the
+  hinge barely bites); free-α-alone gets −2.16 → −3.09; **both together** are the
+  *only* arm that reaches **−3.50** at prod, because free-α pushes the
+  pre-activation floor (−4.80) past the hinge, which then clamps it. The two levers
+  attack opposite regimes and compose at prod — neither alone floors the prod tail;
+  together they do. Ships **default-off** (`output_floor=None`); the shared-α OFF
+  control reproduced #274's separately-fit column to the last decimal, confirming
+  determinism and a fair baseline.
 - **`recompute_scale=False`** (the fixed-scale objective normalizer) converges.
 - **`fit_models` parallelism — settled** (`diagnostics/parallelism_probe.py`):
   `n_processes=2` (the real spawn path) ran the full data-size × l2reg staircase
@@ -144,7 +156,17 @@ downstream from a ModelCollection — the conclusion, the next step.)
     | 4.0e-5 | −4.69 | −3.50 | +1.19 | 17.01 | 21.34 | +4.32 | −15.75 | yes |
     | 1.6e-4 | −3.22 | −3.50 | −0.28 | 14.76 | 19.24 | +4.48 | −16.43 | yes |
     | 6.4e-4 | −2.16 | −2.94 | −0.79 | 13.47 | 17.36 | +3.90 | −2.96 | no |
-  Conclusion: the softplus perturbs the FIT at every fusion strength — fitted shared α is a consistent +3.8…+4.5 higher ON than OFF (+29% at prod), and because the floor is inside predict_score (which the loss uses) this is a real optimization effect, not fit-to-fit noise. Two regimes: at weak fusion (0…1.6e-4) the shared-α sigmoid drives Delta's raw pre-activation floor to −15…−17 (far past the biological −3.5) and the softplus HARD-TRUNCATES it to exactly −3.5 (the assay detection floor); at prod fusion (6.4e-4) the raw floor only reaches −2.96 so the hinge itself clips almost nothing (−2.96→−2.94), but the OFF→ON floor still deepens −2.16→−2.94 driven by the genuinely higher fitted α the floor induced, not by the hinge biting. vs #274 free-α (which DEEPENS the under-shooting prod floor −2.16→−3.09 by selectively decoupling Delta's α): the softplus is a BLUNT clip that floors all three conditions and mainly bites the over-shooting weak-fusion tail — it does NOT pull the prod floor to −3.5 on its own. Complementary, opposite regimes. Convergence: pkl carries no converged/final_obj_err column (computed downstream); #274 saw 0/16 at these tols; all 16 fits completed, floor introduced no failures. Next: for a floored prod recommendation, pair the softplus with free-α or l2reg>0 (softplus alone does not fix the prod under-fit); counts-path floor deferred to a separate stub.
+  Conclusion: the softplus perturbs the FIT at every fusion strength — fitted shared α is a consistent +3.8…+4.5 higher ON than OFF (+29% at prod), and because the floor is inside predict_score (which the loss uses) this is a real optimization effect, not fit-to-fit noise. Two regimes: at weak fusion (0…1.6e-4) the shared-α sigmoid drives Delta's raw pre-activation floor to −15…−17 (far past the biological −3.5) and the softplus HARD-TRUNCATES it to exactly −3.5 (the assay detection floor); at prod fusion (6.4e-4) the raw floor only reaches −2.96 so the hinge itself clips almost nothing (−2.96→−2.94), but the OFF→ON floor still deepens −2.16→−2.94 driven by the genuinely higher fitted α the floor induced, not by the hinge biting. vs #274 free-α (which DEEPENS the under-shooting prod floor −2.16→−3.09 by selectively decoupling Delta's α): the softplus is a BLUNT clip that floors all three conditions and mainly bites the over-shooting weak-fusion tail — it does NOT pull the prod floor to −3.5 on its own. Complementary, opposite regimes. Convergence: pkl carries no converged/final_obj_err column (computed downstream); #274 saw 0/16 at these tols; all 16 fits completed, floor introduced no failures. Next: for a floored prod recommendation, pair the softplus with free-α or l2reg>0 (softplus alone does not fix the prod under-fit); counts-path floor deferred to a separate stub. [SUPERSEDED 2026-07-08 by the free-α arm below — the "pair with free-α" recommendation is now measured directly, not inferred cross-PR.]
+
+- 2026-07-08 | cache=277-softplus-floor-freealpha (ON) + 277-softplus-floor-off-freealpha (OFF control) | The MISSING free-α arm of the 2×2. Same 8-cell grid as the 2026-07-07 shared-α pair but share_alpha=FALSE (the #274 free-α regime, per-condition α) — fit twice, output_floor=-3.5 vs null. 16 fits, 0 failed; wall 1309s (ON) + 1912s (OFF) at n_processes=1. **Ran serial (n_processes=1) deliberately:** the free-α grids deadlocked under the spawn pool (`n_processes=8`) — all 8 workers went to 0% CPU with a shared multiprocessing pipe_handle after a worker re-spawned, a spawn-under-JAX race the heavier free-α compilation widened; serial fits the identical models with no pool. All 16 verified genuinely free-α (per-condition α dict on the fitted model, not shared scalar). Delta floor computed two ways (analytic + model φ=−1e4) — agreed to 0.0e0 on all evals.
+  Full 2×2 Delta floor + Delta's own α (mean over 2 reps):
+    | fusionreg | free OFF floor | free ON floor | shared OFF floor | shared ON floor | free OFF α_Δ | free ON α_Δ | shared α (OFF/ON) |
+    |---|---|---|---|---|---|---|---|
+    | 0.0 | −5.24 | −3.50 | −5.09 | −3.50 | 17.37 | 19.16 | 16.81/20.61 |
+    | 4.0e-5 | −4.82 | −3.50 | −4.69 | −3.50 | 18.07 | 21.20 | 17.01/21.34 |
+    | 1.6e-4 | −3.45 | −3.50 | −3.22 | −3.50 | 12.85 | 17.54 | 14.76/19.24 |
+    | 6.4e-4 | −3.09 | −3.50 | −2.16 | −2.95 | 5.23 | 11.00 | 13.47/17.36 |
+  Conclusion: the two levers are complementary and compose AT PROD. Free-α *deepens the pre-activation floor selectively* — Delta's α at prod drops shared-13.47 → free-5.23 (OFF), taking the OFF prod floor −2.16 → −3.09 with no clip. The softplus is a *blunt clip* to −3.5 wherever the raw pre-activation floor overshoots the hinge. At prod: softplus-alone −2.16→−2.95 (raw floor only −2.96, hinge barely bites, α-driven); free-α-alone −2.16→−3.09; **BOTH together −2.16→−3.50** — the only arm reaching the biological floor at prod, because free-α's deeper −4.80 pre-activation floor now exceeds the hinge and gets clamped. At weak fusion (0…1.6e-4) both α regimes overshoot to −11…−16 pre-activation, so ON pins every cell to exactly −3.5 regardless of share_alpha. This directly measures (not infers) the 2026-07-07 "pair softplus with free-α for a floored prod recommendation" next-step: confirmed — neither lever alone floors the prod tail, together they do. Standing finding rewritten to the 2×2. Next: none for this experiment; the softplus × free-α interaction is settled. Counts-path floor still deferred to stub #276.
 
 - 2026-06-30 | cache=l2-fusion | sweep: l2reg [0.0, 1e-4, 3e-4] × fusionreg [0.0, 4e-5, 6.4e-4], 2 reps (18 fits), warmstart=True, recompute_scale=False, share_alpha=True, Sigmoid, maxiter=25. Independent fitting (#256). Wall 1138s at n_processes=4 (local, Apple M4 Max). Downstream numbers from diagnostics/l2_fusion_report.py.
   Basin diagnostics (Σβ², α per cell): at l2reg=0.0 → Σβ² 16,181–19,222, α 5.9–8.2 (β EXPLODED at EVERY fusionreg, incl. 6.4e-4). l2reg=1e-4 → Σβ² 554–841, α 19.5–24.6 (β tamed ~25× into the healthy 350–1400 band, holds across all fusion). l2reg=3e-4 → Σβ² 188–298, α 30.5–40.4 (β tamed further but α climbing toward the see-saw collapse end). All 18 converged=False, but final_obj_err is tiny (4e-6 at l2reg=0 to ~7e-4 at l2reg>0) — maxiter=25 truncation, not a pathology; β-magnitude and r are trustworthy, the binary flag is not.

--- a/experiments/convergence-lab/grids/softplus-floor-freealpha.yaml
+++ b/experiments/convergence-lab/grids/softplus-floor-freealpha.yaml
@@ -1,0 +1,26 @@
+# softplus-floor × FREE-α, floor ON (#277) — the missing free-α arm of the 2×2.
+# #274 (Free-Alpha) is defined by share_alpha=false; this grid runs the softplus
+# floor (lower_bound=-3.5) ON in that regime so the softplus × share_alpha
+# interaction is measured in ONE harness rather than quoted cross-PR.
+# fusionreg [0, 4e-5, 1.6e-4, 6.4e-4] × 2 reps = 8 fits.
+sweep:
+  fusionreg: [0.0, 4.0e-5, 1.6e-4, 6.4e-4]      # same 4-point axis as #274
+fixed:
+  output_floor: -3.5                            # THE new lever — on for every cell
+  share_alpha: false                            # #274 free-α condition (per-condition α)
+  # --- #274 free-alpha.yaml fixed block, VERBATIM (= PR 270 recompute-false) ---
+  warmstart: false
+  recompute_scale: false
+  ge_type: Sigmoid
+  l2reg: 0.0
+  beta0_ridge: 0.0
+  scale_fusion_by_n: false
+  alpha_init: 6.0
+  beta0_init: {Omicron_BA1: 0.0, Delta: 0.0, Omicron_BA2: 0.0}
+  beta_clip_range: [-10, 10]
+  loss_kwargs: {δ: 1.0}
+  maxiter: 50                                   # outer block cap
+  tol: 1.0e-5                                   # outer tol (loosened from PR 270's 1e-6)
+  ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+  cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+replicates: [1, 2]

--- a/experiments/convergence-lab/grids/softplus-floor-off-freealpha.yaml
+++ b/experiments/convergence-lab/grids/softplus-floor-off-freealpha.yaml
@@ -1,0 +1,26 @@
+# softplus-floor × FREE-α, floor OFF (#277) — the matched OFF control for the
+# free-α arm of the 2×2. share_alpha=false (the #274 regime) with output_floor
+# null, so the softplus toggle is a controlled comparison against
+# softplus-floor-freealpha.yaml within ONE harness.
+# fusionreg [0, 4e-5, 1.6e-4, 6.4e-4] × 2 reps = 8 fits.
+sweep:
+  fusionreg: [0.0, 4.0e-5, 1.6e-4, 6.4e-4]      # same 4-point axis as #274
+fixed:
+  output_floor: null                            # OFF control — matched in-harness baseline
+  share_alpha: false                            # #274 free-α condition (per-condition α)
+  # --- #274 free-alpha.yaml fixed block, VERBATIM (= PR 270 recompute-false) ---
+  warmstart: false
+  recompute_scale: false
+  ge_type: Sigmoid
+  l2reg: 0.0
+  beta0_ridge: 0.0
+  scale_fusion_by_n: false
+  alpha_init: 6.0
+  beta0_init: {Omicron_BA1: 0.0, Delta: 0.0, Omicron_BA2: 0.0}
+  beta_clip_range: [-10, 10]
+  loss_kwargs: {δ: 1.0}
+  maxiter: 50                                   # outer block cap
+  tol: 1.0e-5                                   # outer tol (loosened from PR 270's 1e-6)
+  ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+  cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+replicates: [1, 2]

--- a/experiments/convergence-lab/grids/softplus-floor-off.yaml
+++ b/experiments/convergence-lab/grids/softplus-floor-off.yaml
@@ -1,0 +1,25 @@
+# softplus-floor OFF control (#277) — does an explicit softplus output floor
+# (lower_bound=-3.5) deepen Delta's under-fit low tail the way freeing α did in
+# #274? Floor OFF (output_floor=null) — the MATCHED in-harness baseline for the ON run,
+# so the A/B is a controlled toggle in ONE harness. fusionreg [0, 4e-5, 1.6e-4, 6.4e-4] × 2 reps = 8 fits.
+sweep:
+  fusionreg: [0.0, 4.0e-5, 1.6e-4, 6.4e-4]      # same 4-point axis as #274
+fixed:
+  output_floor: null                           # OFF control — matched in-harness baseline
+  share_alpha: true                             # #274 baseline (shared-α) condition
+  # --- #274 free-alpha.yaml fixed block, VERBATIM (= PR 270 recompute-false) ---
+  warmstart: false
+  recompute_scale: false
+  ge_type: Sigmoid
+  l2reg: 0.0
+  beta0_ridge: 0.0
+  scale_fusion_by_n: false
+  alpha_init: 6.0
+  beta0_init: {Omicron_BA1: 0.0, Delta: 0.0, Omicron_BA2: 0.0}
+  beta_clip_range: [-10, 10]
+  loss_kwargs: {δ: 1.0}
+  maxiter: 50                                   # outer block cap
+  tol: 1.0e-5                                   # outer tol (loosened from PR 270's 1e-6)
+  ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+  cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+replicates: [1, 2]

--- a/experiments/convergence-lab/grids/softplus-floor.yaml
+++ b/experiments/convergence-lab/grids/softplus-floor.yaml
@@ -1,0 +1,25 @@
+# softplus-floor grid (#277) — does an explicit softplus output floor
+# (lower_bound=-3.5) deepen Delta's under-fit low tail the way freeing α did in
+# #274? Floor fixed ON for all cells; A/B is cross-PR vs #274's shared-α column.
+# output_floor [-3.5] × fusionreg [0, 4e-5, 1.6e-4, 6.4e-4] × 2 reps = 8 fits.
+sweep:
+  fusionreg: [0.0, 4.0e-5, 1.6e-4, 6.4e-4]      # same 4-point axis as #274
+fixed:
+  output_floor: -3.5                            # THE new lever — on for every cell
+  share_alpha: true                             # #274 baseline (shared-α) condition
+  # --- #274 free-alpha.yaml fixed block, VERBATIM (= PR 270 recompute-false) ---
+  warmstart: false
+  recompute_scale: false
+  ge_type: Sigmoid
+  l2reg: 0.0
+  beta0_ridge: 0.0
+  scale_fusion_by_n: false
+  alpha_init: 6.0
+  beta0_init: {Omicron_BA1: 0.0, Delta: 0.0, Omicron_BA2: 0.0}
+  beta_clip_range: [-10, 10]
+  loss_kwargs: {δ: 1.0}
+  maxiter: 50                                   # outer block cap
+  tol: 1.0e-5                                   # outer tol (loosened from PR 270's 1e-6)
+  ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+  cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+replicates: [1, 2]

--- a/experiments/convergence-lab/harness.py
+++ b/experiments/convergence-lab/harness.py
@@ -78,6 +78,8 @@ VALID_KWARGS = frozenset(
         "fusionreg",
         "beta0_ridge",
         "scale_fusion_by_n",
+        "output_floor",
+        "output_floor_hinge",
         "loss_type",
         "maxiter",
         "tol",

--- a/multidms/jaxmodels.py
+++ b/multidms/jaxmodels.py
@@ -288,6 +288,9 @@ class Model(eqx.Module):
     reference_condition: str = eqx.field(static=True)
     """The condition to use as a reference."""
     global_epistasis: GlobalEpistasis = eqx.field(default=Identity(), static=True)
+    output_activation: OutputActivation = eqx.field(
+        default=IdentityOutput(), static=True
+    )
 
     def predict_score(
         self,
@@ -306,8 +309,8 @@ class Model(eqx.Module):
             α = self.α[d] if α_is_dict else self.α
             X = data_sets[d].X
             x_wt = data_sets[d].x_wt
-            result[d] = α * (
-                self.global_epistasis(φ(X)) - self.global_epistasis(φ(x_wt))
+            result[d] = self.output_activation(
+                α * (self.global_epistasis(φ(X)) - self.global_epistasis(φ(x_wt)))
             )
         return result
 
@@ -427,6 +430,7 @@ def fit(
     ge_kwargs: dict[str, Any] = dict(),
     cal_kwargs: dict[str, Any] = dict(),
     global_epistasis: GlobalEpistasis = Identity(),
+    output_activation: OutputActivation = IdentityOutput(),
     loss_fn: Callable[
         [Model, dict[str, Data]], dict[str, Float[Array, ""]]
     ] = functional_score_loss,
@@ -616,6 +620,7 @@ def fit(
         logθ=True,
         reference_condition=reference_condition,
         global_epistasis=global_epistasis,
+        output_activation=output_activation,
     )
     filter_spec_β0 = Model(
         φ={d: Latent(β0=True, β=False) for d in data_sets},
@@ -623,6 +628,7 @@ def fit(
         logθ=False,
         reference_condition=reference_condition,
         global_epistasis=global_epistasis,
+        output_activation=output_activation,
     )
 
     # initialize latent models with independent control over each parameter
@@ -675,6 +681,7 @@ def fit(
         logθ={d: jnp.array(0.0) for d in data_sets},
         reference_condition=reference_condition,
         global_epistasis=global_epistasis,
+        output_activation=output_activation,
     )
 
     # track convergence trajectory

--- a/multidms/jaxmodels.py
+++ b/multidms/jaxmodels.py
@@ -226,9 +226,7 @@ class OutputActivation(eqx.Module, abc.ABC):
     r"""Activation applied to the model's predicted functional score."""
 
     @abc.abstractmethod
-    def __call__(
-        self, y: Float[Array, " n_variants"]
-    ) -> Float[Array, " n_variants"]:
+    def __call__(self, y: Float[Array, " n_variants"]) -> Float[Array, " n_variants"]:
         r"""Apply the output activation.
 
         Args:
@@ -242,9 +240,7 @@ class OutputActivation(eqx.Module, abc.ABC):
 class IdentityOutput(OutputActivation):
     r"""Pass-through output activation (no floor). The default."""
 
-    def __call__(
-        self, y: Float[Array, " n_variants"]
-    ) -> Float[Array, " n_variants"]:
+    def __call__(self, y: Float[Array, " n_variants"]) -> Float[Array, " n_variants"]:
         r"""Return input unchanged."""
         return y
 
@@ -268,9 +264,7 @@ class Softplus(OutputActivation):
     lower_bound: float = -3.5
     hinge_scale: float = 0.1
 
-    def __call__(
-        self, y: Float[Array, " n_variants"]
-    ) -> Float[Array, " n_variants"]:
+    def __call__(self, y: Float[Array, " n_variants"]) -> Float[Array, " n_variants"]:
         r"""Apply the softplus floor."""
         lb, λ = self.lower_bound, self.hinge_scale
         return λ * jnp.logaddexp(0.0, (y - lb) / λ) + lb
@@ -461,6 +455,8 @@ def fit(
         cal_kwargs: Keyword arguments for the experimental calibration
                     parameter optimizer.
         global_epistasis: Global epistasis model.
+        output_activation: Output activation applied to predicted functional
+            scores. Defaults to :class:`IdentityOutput` (no floor).
         loss_fn: Loss function.
         loss_kwargs: Keyword arguments for the loss function.
         warmstart: Whether to use Ridge regression warmstart (default: True).

--- a/multidms/jaxmodels.py
+++ b/multidms/jaxmodels.py
@@ -222,6 +222,60 @@ class Sigmoid(GlobalEpistasis):
         return jax.scipy.special.expit(x)
 
 
+class OutputActivation(eqx.Module, abc.ABC):
+    r"""Activation applied to the model's predicted functional score."""
+
+    @abc.abstractmethod
+    def __call__(
+        self, y: Float[Array, " n_variants"]
+    ) -> Float[Array, " n_variants"]:
+        r"""Apply the output activation.
+
+        Args:
+            y: The pre-activation predicted functional score.
+
+        Returns:
+            The activated functional score.
+        """
+
+
+class IdentityOutput(OutputActivation):
+    r"""Pass-through output activation (no floor). The default."""
+
+    def __call__(
+        self, y: Float[Array, " n_variants"]
+    ) -> Float[Array, " n_variants"]:
+        r"""Return input unchanged."""
+        return y
+
+
+class Softplus(OutputActivation):
+    r"""Smooth differentiable lower floor on the predicted functional score.
+
+    Reproduces the manuscript-era ``biophysical.py::softplus_activation``:
+
+    .. math::
+
+        t(y) = \lambda \cdot \log\!\left(1 + e^{(y - l)/\lambda}\right) + l
+
+    where :math:`l` is ``lower_bound`` and :math:`\lambda` is ``hinge_scale``.
+    For :math:`y \gg l` it is approximately the identity; for :math:`y \ll l`
+    it flattens toward :math:`l` (from above; :math:`t(y) > l` for all finite
+    :math:`y`). The floor is *soft* — at :math:`y = l`,
+    :math:`t = l + \lambda\log 2`, not exactly :math:`l`.
+    """
+
+    lower_bound: float = -3.5
+    hinge_scale: float = 0.1
+
+    def __call__(
+        self, y: Float[Array, " n_variants"]
+    ) -> Float[Array, " n_variants"]:
+        r"""Apply the softplus floor."""
+        lb, λ = self.lower_bound, self.hinge_scale
+        return λ * jnp.logaddexp(0.0, (y - lb) / λ) + lb
+
+
 class Model(eqx.Module):
     r"""Model DMS data."""
 

--- a/multidms/model.py
+++ b/multidms/model.py
@@ -66,6 +66,8 @@ class Model:
         fusionreg: float = 0.0,
         beta0_ridge: float = 0.0,
         scale_fusion_by_n: bool = False,
+        output_floor: float | None = None,
+        output_floor_hinge: float = 0.1,
     ):
         """Initialize Model with data and hyperparameters."""
         # Validate inputs
@@ -76,6 +78,15 @@ class Model:
             )
         if ge_type not in ["Identity", "Sigmoid"]:
             raise ValueError(f"ge_type must be 'Identity' or 'Sigmoid', got {ge_type}")
+        if output_floor is not None and not isinstance(output_floor, (int, float)):
+            raise ValueError(
+                f"output_floor must be None or a float, got {output_floor!r}"
+            )
+        if not isinstance(output_floor_hinge, (int, float)) or output_floor_hinge <= 0:
+            raise ValueError(
+                f"output_floor_hinge must be a positive float, got "
+                f"{output_floor_hinge!r}"
+            )
 
         # Store configuration
         self._data = data
@@ -85,6 +96,8 @@ class Model:
         self._fusionreg = fusionreg
         self._beta0_ridge = beta0_ridge
         self._scale_fusion_by_n = scale_fusion_by_n
+        self._output_floor = output_floor
+        self._output_floor_hinge = output_floor_hinge
 
         # Will be populated by fit()
         self._jax_model = None
@@ -228,6 +241,15 @@ class Model:
         else:
             raise ValueError(f"Unknown ge_type: {self._ge_type}")
 
+        # Set up output activation (softplus floor, default off)
+        if self._output_floor is None:
+            output_activation = jaxmodels.IdentityOutput()
+        else:
+            output_activation = jaxmodels.Softplus(
+                lower_bound=self._output_floor,
+                hinge_scale=self._output_floor_hinge,
+            )
+
         # Set up loss function
         if self._loss_type == "functional_score_loss":
             loss_fn = jaxmodels.functional_score_loss
@@ -252,6 +274,7 @@ class Model:
             block_iters=maxiter,
             block_tol=tol,
             global_epistasis=global_epistasis,
+            output_activation=output_activation,
             loss_fn=loss_fn,
             warmstart=warmstart,
             recompute_scale=recompute_scale,
@@ -925,14 +948,28 @@ class Model:
 
     def __repr__(self):
         """String representation."""
-        return f"Model(ge_type='{self._ge_type}', loss_type='{self._loss_type}')"
+        floor = (
+            f", output_floor={self._output_floor}"
+            if self._output_floor is not None
+            else ""
+        )
+        return (
+            f"Model(ge_type='{self._ge_type}', "
+            f"loss_type='{self._loss_type}'{floor})"
+        )
 
     def __str__(self):
         """Detailed string representation."""
         fitted = "fitted" if self._jax_model is not None else "not fitted"
+        floor_line = (
+            f"  output_floor: {self._output_floor}\n"
+            if self._output_floor is not None
+            else ""
+        )
         return (
             f"Model\n"
             f"  ge_type: {self._ge_type}\n"
+            f"{floor_line}"
             f"  loss_type: {self._loss_type}\n"
             f"  l2reg: {self._l2reg}\n"
             f"  fusionreg: {self._fusionreg}\n"

--- a/multidms/model_collection.py
+++ b/multidms/model_collection.py
@@ -65,6 +65,8 @@ def fit_one_model(
     fusionreg=0.0,
     beta0_ridge=0.0,
     scale_fusion_by_n=False,
+    output_floor=None,
+    output_floor_hinge=0.1,
     loss_type="functional_score_loss",
     maxiter=10,
     tol=1e-6,
@@ -102,6 +104,13 @@ def fit_one_model(
         Ridge penalty for beta0 differences from reference condition.
     scale_fusion_by_n : bool
         Weight each condition's fusion penalty by n_ref / n_d.
+    output_floor : float or None
+        Softplus output-activation lower bound. ``None`` (default) disables
+        the floor (identity output). A float sets the floor at that value
+        (e.g. ``-3.5``), softly hinging predicted functional scores from above.
+    output_floor_hinge : float
+        Softplus ramp width (``hinge_scale``). Only meaningful when
+        ``output_floor`` is set. Default ``0.1``.
     loss_type : str
         Loss function: ``'functional_score_loss'`` or ``'count_loss'``.
     maxiter : int
@@ -147,6 +156,8 @@ def fit_one_model(
         fusionreg=fusionreg,
         beta0_ridge=beta0_ridge,
         scale_fusion_by_n=scale_fusion_by_n,
+        output_floor=output_floor,
+        output_floor_hinge=output_floor_hinge,
         loss_type=loss_type,
     )
 

--- a/tests/test_jaxmodels.py
+++ b/tests/test_jaxmodels.py
@@ -317,6 +317,66 @@ class TestOutputActivation:
         # At the hinge, value = l + λ·log2, so larger λ → larger offset above l
         assert float(wide(y)) > float(sharp(y))
 
+    def _fitted_params(self, model):
+        """Extract (α, per-condition β) as concrete arrays for comparison."""
+        α = model.α
+        βs = {d: model.φ[d].β for d in model.φ}
+        return α, βs
+
+    def test_fit_merge_safety_default_is_fieldfree(self, multi_condition_data):
+        """Default (arg omitted) fit == explicit IdentityOutput fit, bitwise.
+
+        Guards spec's merge-safety invariant: the new static field must not
+        shift equinox partitioning or the optimizer. Compares fitted α, β, and
+        predict_score outputs via jnp.array_equal.
+        """
+        common = dict(reference_condition="condition1", block_iters=5)
+        # Arm 1: output_activation argument OMITTED (the main-era code path).
+        m_omitted, _ = jaxmodels.fit(data_sets=multi_condition_data, **common)
+        # Arm 2: explicit IdentityOutput.
+        m_explicit, _ = jaxmodels.fit(
+            data_sets=multi_condition_data,
+            output_activation=jaxmodels.IdentityOutput(),
+            **common,
+        )
+        α1, β1 = self._fitted_params(m_omitted)
+        α2, β2 = self._fitted_params(m_explicit)
+        # α may be a scalar or a dict depending on share_alpha; handle both.
+        if isinstance(α1, dict):
+            for d in α1:
+                assert jnp.array_equal(α1[d], α2[d])
+        else:
+            assert jnp.array_equal(α1, α2)
+        for d in β1:
+            assert jnp.array_equal(β1[d], β2[d])
+        p1 = m_omitted.predict_score(multi_condition_data)
+        p2 = m_explicit.predict_score(multi_condition_data)
+        for d in p1:
+            assert jnp.array_equal(p1[d], p2[d])
+
+    def test_fit_softplus_changes_predictions(self, multi_condition_data):
+        """A Softplus fit produces DIFFERENT predict_score than the default fit.
+
+        Positive control: proves the floor is actually wired into predict_score
+        (not inert). Complements the merge-safety test above.
+        """
+        common = dict(reference_condition="condition1", block_iters=5)
+        m_off, _ = jaxmodels.fit(data_sets=multi_condition_data, **common)
+        m_on, _ = jaxmodels.fit(
+            data_sets=multi_condition_data,
+            output_activation=jaxmodels.Softplus(lower_bound=0.0, hinge_scale=0.1),
+            **common,
+        )
+        # lower_bound=0.0 forces a visible change even on this small toy data
+        # (many toy scores sit below 0), so the ON/OFF predictions must differ.
+        p_off = m_off.predict_score(multi_condition_data)
+        p_on = m_on.predict_score(multi_condition_data)
+        differs = any(not jnp.array_equal(p_off[d], p_on[d]) for d in p_off)
+        assert differs, "Softplus floor did not change predict_score — not wired"
+        # And the floored predictions never fall below the (soft) bound.
+        for d in p_on:
+            assert jnp.all(p_on[d] >= 0.0)
+
 
 # ==================== Tests for Model fitting with beta clipping ====================
 

--- a/tests/test_jaxmodels.py
+++ b/tests/test_jaxmodels.py
@@ -259,6 +259,65 @@ class TestGlobalEpistasis:
         assert y[2] < y[0]  # sigmoid(-1) < sigmoid(0)
 
 
+# ==================== Tests for Output Activation ====================
+
+
+class TestOutputActivation:
+    """Tests for the softplus output-activation floor (issue #277)."""
+
+    def test_identity_output_passthrough(self):
+        """IdentityOutput returns its input unchanged."""
+        act = jaxmodels.IdentityOutput()
+        y = jnp.array([-5.0, -3.5, 0.0, 2.0, 100.0])
+        assert jnp.array_equal(act(y), y)
+
+    def test_softplus_asymptotics(self):
+        """Softplus ≈ identity well above l, → l from above well below l.
+
+        Note the floor is soft in exact arithmetic (t(y) > l for all finite y),
+        but in floating point the ``exp((y-l)/λ)`` term underflows to 0 once y is
+        more than ~36λ below l, so t(y) == l exactly there. The meaningful
+        invariants are therefore: t(y) never dips *below* l, and t(y) is strictly
+        above l within the transition region (a few λ of the bound).
+        """
+        act = jaxmodels.Softplus(lower_bound=-3.5, hinge_scale=0.1)
+        # Well above the floor: t(y) ≈ y
+        high = jnp.array([0.0, 2.0, 10.0])
+        assert jnp.allclose(act(high), high, atol=1e-3)
+        # Well below the floor: t(y) → l from above; never below l
+        low = jnp.array([-10.0, -20.0, -100.0])
+        out_low = act(low)
+        assert jnp.allclose(out_low, -3.5, atol=1e-3)
+        assert jnp.all(out_low >= -3.5)
+        # Strictly above l in the transition region (before float underflow)
+        near = jnp.array([-3.6, -3.5, 0.0, 50.0])
+        assert jnp.all(act(near) > -3.5)
+
+    def test_softplus_known_answer_at_hinge(self):
+        """At y = l, t(l) = l + λ·log(2) exactly."""
+        act = jaxmodels.Softplus(lower_bound=-3.5, hinge_scale=0.1)
+        expected = -3.5 + 0.1 * jnp.log(2.0)
+        np.testing.assert_allclose(act(jnp.array(-3.5)), expected, rtol=1e-6)
+
+    def test_softplus_gradient_is_sigmoid(self):
+        """d/dy t(y) = sigmoid((y-l)/λ): 0.5 at y=l, →1 above, →0 below."""
+        act = jaxmodels.Softplus(lower_bound=-3.5, hinge_scale=0.1)
+        grad = jax.grad(lambda y: act(y).sum())
+        # At the hinge, slope is 0.5
+        np.testing.assert_allclose(grad(jnp.array(-3.5)), 0.5, rtol=1e-5)
+        # Far above → 1, far below → 0
+        np.testing.assert_allclose(grad(jnp.array(10.0)), 1.0, atol=1e-4)
+        np.testing.assert_allclose(grad(jnp.array(-20.0)), 0.0, atol=1e-4)
+
+    def test_softplus_hinge_scale_controls_ramp(self):
+        """A smaller hinge_scale makes the transition sharper at the hinge value."""
+        y = jnp.array(-3.5)  # the hinge point for lower_bound=-3.5
+        sharp = jaxmodels.Softplus(lower_bound=-3.5, hinge_scale=0.01)
+        wide = jaxmodels.Softplus(lower_bound=-3.5, hinge_scale=1.0)
+        # At the hinge, value = l + λ·log2, so larger λ → larger offset above l
+        assert float(wide(y)) > float(sharp(y))
+
+
 # ==================== Tests for Model fitting with beta clipping ====================
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1288,3 +1288,32 @@ def test_plot_ge_landscape_func_score_convenience(fitted_simple_model):
         for row in rows:
             all_columns.update(row.keys())
     assert "func_score_curve_value" in all_columns
+
+
+def test_output_floor_toggle(simple_data):
+    """output_floor=-3.5 is advertised in repr/str; default (None) is not.
+
+    Also exercises the validation path and confirms a floored model fits.
+    """
+    m_off = multidms.Model(simple_data, ge_type="Sigmoid")
+    m_off.fit(maxiter=3, warmstart=False)
+    m_on = multidms.Model(simple_data, ge_type="Sigmoid", output_floor=-3.5)
+    m_on.fit(maxiter=3, warmstart=False)
+
+    # Default off: neither repr nor str advertises a floor.
+    assert "output_floor" not in repr(m_off)
+    assert "output_floor" not in str(m_off)
+    # On: both advertise the floor and its value.
+    assert "output_floor" in repr(m_on)
+    assert "-3.5" in repr(m_on)
+    assert "output_floor" in str(m_on)
+
+
+def test_output_floor_validation(simple_data):
+    """output_floor must be None/float; output_floor_hinge a positive float."""
+    with pytest.raises(ValueError, match="output_floor"):
+        multidms.Model(simple_data, output_floor="not-a-number")
+    with pytest.raises(ValueError, match="output_floor_hinge"):
+        multidms.Model(simple_data, output_floor=-3.5, output_floor_hinge=0.0)
+    with pytest.raises(ValueError, match="output_floor_hinge"):
+        multidms.Model(simple_data, output_floor=-3.5, output_floor_hinge=-1.0)

--- a/tests/test_model_collection.py
+++ b/tests/test_model_collection.py
@@ -1214,3 +1214,39 @@ class TestConcatPathTrajectories:
         out = concat_path_trajectories(empty)
         assert isinstance(out, pd.DataFrame)
         assert len(out) == 0
+
+
+def test_fit_one_model_output_floor_is_live(simple_data):
+    """output_floor passed to fit_one_model actually CHANGES predict_score.
+
+    Guards the silent-swallow trap: fit_one_model's **kwargs would absorb
+    output_floor without error if it weren't threaded into Model(...), yielding
+    softplus-OFF numbers mislabeled as ON. A pure `> -3.5` check cannot catch
+    that (it holds for the swallowed case too); a difference check can.
+    """
+    import jax.numpy as jnp
+    from multidms.model_collection import fit_one_model
+
+    off = fit_one_model(
+        dataset=simple_data, ge_type="Sigmoid", maxiter=5, output_floor=None
+    )
+    on = fit_one_model(
+        dataset=simple_data, ge_type="Sigmoid", maxiter=5, output_floor=-3.5
+    )
+    # Bookkeeping records the value.
+    assert on["output_floor"] == -3.5
+    assert off["output_floor"] is None
+
+    m_off, m_on = off["model"], on["model"]
+    p_off = m_off._jax_model.predict_score(m_off._jax_data_sets)
+    p_on = m_on._jax_model.predict_score(m_on._jax_data_sets)
+
+    # The floor must CHANGE at least one condition's predictions. If it were
+    # swallowed by **kwargs, both fits are identical and this fails — the trap
+    # is caught.
+    differs = any(not jnp.array_equal(p_off[c], p_on[c]) for c in p_off)
+    assert differs, "output_floor was swallowed — predictions unchanged"
+
+    # And the floored predictions never fall below the soft bound.
+    for c in p_on:
+        assert (p_on[c] >= -3.5).all()


### PR DESCRIPTION
Closes #277.

## Summary

Adds a **default-off softplus output-activation floor** to the current model —
reviving the manuscript-era `biophysical.py::softplus_activation` (removed in the
`jaxmodels` rewrite) as a well-coded API toggle — and runs a **matched
convergence-lab A/B** to test what the floor does to Delta's under-fit low tail.

**Model change (mergeable independent of the experiment, zero behavioral change
on `main`):** an `OutputActivation` eqx hierarchy mirroring the existing
`GlobalEpistasis`/`Sigmoid` pattern — `IdentityOutput` (default, pass-through) and
`Softplus(lower_bound=-3.5, hinge_scale=0.1)` — threaded through
`jaxmodels.Model`/`fit()`, exposed on the wrapper `Model` as `output_floor` /
`output_floor_hinge` and on `fit_one_model`, plus the two keys in the
convergence-lab harness `VALID_KWARGS`. With `output_floor=None` (the default on
every layer) the model is bitwise-identical to `main`.

**Experiment:** the exact #274 (Free-Alpha) 8-cell grid — `fusionreg [0, 4e-5,
1.6e-4, 6.4e-4] × 2 reps`, #274's fixed block verbatim — fit as a **full 2×2**:
`{output_floor=-3.5 ON, null OFF} × {share_alpha=true, false}`. The
`share_alpha=false` cells put the softplus in #274's own free-α regime, so the
softplus × free-α comparison is measured **in one harness**, not quoted cross-PR.
**32 fits, 0 failed.**

## The finding — full softplus × share_α 2×2

Delta's floor computed two ways (analytic `t(−α·g(φ_wt))` and the model
composition at φ=−1e4) — **agreed to 0.0e0 on all 32 fit-evals**. All 16 free-α
fits verified genuinely per-condition α (dict on the fitted model, not a shared
scalar). The shared-α OFF control reproduces #274's separately-fit column to the
last decimal (floor −5.08/−4.69/−3.22/−2.16, α 16.81/17.01/14.76/13.47),
validating fit determinism and #274's baseline.

### Delta floor, mean over 2 reps

| fusionreg | free OFF | free ON | shared OFF | shared ON |
|---|---|---|---|---|
| 0.0 | −5.24 | **−3.50** | −5.09 | **−3.50** |
| 4.0e-5 | −4.82 | **−3.50** | −4.69 | **−3.50** |
| 1.6e-4 | −3.45 | **−3.50** | −3.22 | **−3.50** |
| **6.4e-4** | **−3.09** | **−3.50** | −2.16 | −2.95 |

### Delta's own α (free) vs shared α, mean over 2 reps

| fusionreg | free OFF | free ON | shared OFF | shared ON |
|---|---|---|---|---|
| 0.0 | 17.37 | 19.16 | 16.81 | 20.61 |
| 4.0e-5 | 18.07 | 21.20 | 17.01 | 21.34 |
| 1.6e-4 | 12.85 | 17.54 | 14.76 | 19.24 |
| **6.4e-4** | **5.23** | 11.00 | 13.47 | 17.36 |

**The two levers attack opposite regimes and compose at prod — only BOTH together
floor the prod tail to the biological −3.5.**

- **Softplus = blunt clip.** It hard-truncates Delta's *pre-activation* floor to
  −3.5 wherever that raw floor overshoots the hinge. At weak fusion (0 → 1.6e-4)
  both α regimes drive the pre-activation floor to −11…−16 (far past −3.5), so ON
  pins every one of those cells to exactly −3.5 regardless of `share_alpha`. The
  floor lives inside `predict_score` (the loss uses it), so ON also perturbs the
  fit everywhere — fitted α lands consistently higher ON than OFF in both regimes.
- **Free-α = selective deepening.** Letting Delta's own α decouple drops it sharply
  at prod (shared 13.47 → free **5.23** OFF), which by itself deepens the OFF prod
  floor −2.16 → −3.09 with no clip.
- **The prod cell is the whole point.** softplus-alone: −2.16 → **−2.95**
  (α-driven; raw floor only −2.96 so the hinge barely bites). free-α-alone:
  −2.16 → **−3.09**. **Both together: −2.16 → −3.50** — the *only* arm reaching the
  biological floor at prod, because free-α's deeper −4.80 pre-activation floor now
  exceeds the hinge and gets clamped.

So the earlier shared-α-only conclusion ("softplus does not, on its own, pull the
prod floor to −3.5 — pair it with free-α") is now **demonstrated in-harness, not
inferred**: `free ON` is the unique cell that hits −3.50 at prod.

Convergence: the harness pkl carries no `converged`/`final_obj_err` column
(computed downstream); #274 saw 0/16 at these looser tols; all 32 fits completed,
the floor introduced no failures. The floor/α numbers are trustworthy (analytic
and model agree exactly); the binary flag, were it computed, would not be.

Convergence: the harness pkl carries no `converged`/`final_obj_err` column
(computed downstream); #274 saw 0/16 at these looser tols; all 16 fits completed,
the floor introduced no failures. The floor/α numbers are trustworthy (analytic
and model agree exactly); the binary flag, were it computed, would not be.

## Tests

- `Softplus` asymptotics, known-answer at the hinge (`t(-3.5) = -3.5 + 0.1·log 2`),
  gradient = `sigmoid((y-l)/λ)`, hinge-scale control, `IdentityOutput`
  pass-through.
- **Merge-safety** (`test_fit_merge_safety_default_is_fieldfree`): a fit with the
  `output_activation` argument *omitted* (the `main`-era path) is bitwise-identical
  in α, β, and `predict_score` to an explicit `IdentityOutput()` fit.
- **Positive control** (`test_fit_softplus_changes_predictions`): a `Softplus` fit
  produces different `predict_score` than the default — proves the floor is wired.
- **Silent-swallow guard** (`test_fit_one_model_output_floor_is_live`): asserts
  `output_floor` passed to `fit_one_model` *changes* predictions, catching the trap
  where `**kwargs` would absorb it as a no-op.
- Wrapper repr/str + validation.

`pixi run test` (CI-equivalent fast set) = 53 passed; full `test_jaxmodels.py` = 45
passed (merge-safety regression); `ruff check .` + `black --check` clean.

## How to reproduce

From `experiments/convergence-lab/`:

```bash
# shared-α arm (n_processes ok)
pixi run python harness.py --config grids/softplus-floor.yaml     --cache 277-softplus-floor           # ON
pixi run python harness.py --config grids/softplus-floor-off.yaml --cache 277-softplus-floor-off       # OFF
# free-α arm — MUST run serial (n_processes=1); the spawn pool deadlocks here (see Deviations)
pixi run python harness.py --config grids/softplus-floor-freealpha.yaml     --cache 277-softplus-floor-freealpha     --n-processes 1  # ON
pixi run python harness.py --config grids/softplus-floor-off-freealpha.yaml --cache 277-softplus-floor-off-freealpha --n-processes 1  # OFF
pixi run dashboard   # rglobs fit_collection.pkl below cwd
```

The pkls are gitignored — regenerated on demand. Shared-α arm ~307s + ~326s at
n_processes=8; free-α arm 1309s + 1912s at n_processes=1 (serial).

## Deviations from spec

- **Soft-floor test assertions (numerical).** The spec's soft-floor note says
  `t(y) > l` strictly "for every finite y". True in exact arithmetic, but in
  float64 `exp((y−l)/λ)` underflows to 0 once `y < l − ~36λ`, so `t(y) == l`
  exactly there. The tests therefore assert `t(y) >= l` always **and** strict
  `t(y) > l` within the transition region (a few λ of the bound), not literal
  strict inequality at all finite y. Behavior matches the manuscript
  implementation exactly; only the test wording changed.
- **Added a matched OFF-control fit + grid** (`grids/softplus-floor-off.yaml`,
  `output_floor: null`), not in the spec. The spec's A/B was cross-PR (ON here vs
  #274's quoted OFF column). A surprising-conclusion skeptic pass found that the
  softplus shifts the fitted α by +29% at prod, so the two arms are not a
  controlled toggle unless OFF is re-fit under the *same* harness. Re-fitting OFF
  in-harness converts the comparison to a clean controlled toggle; it reproduced
  #274's numbers exactly, confirming the original baseline was fair. This
  strengthens the finding beyond the spec's plan.
- **Corrected interpretation.** An earlier draft called the prod-fusion effect an
  "α-landing artifact / near-inert". The skeptic pass showed this was backwards —
  the +3.8…+4.5 α shift is a real, consistent fitting effect, not noise. The
  reported interpretation reflects the corrected reading.
- **Added the free-α arm — full 2×2 instead of a shared-α-only A/B** (grids
  `softplus-floor-freealpha.yaml` and `softplus-floor-off-freealpha.yaml`,
  `share_alpha=false`). The spec's experiment was softplus ON/OFF at
  `share_alpha=true` only, with the #274 free-α comparison left cross-PR. Because
  the whole question is "does the softplus do what freeing α did," the `share_alpha
  =false` cells belong in the same harness. Adding them turns the result into a
  measured softplus × free-α interaction and confirms the shared-α-only conclusion
  directly: `free ON` is the unique arm that floors the prod tail to −3.50.
  16 extra fits, 0 failed, all verified genuinely per-condition free-α.
- **Free-α arm fit serially (`n_processes=1`), not with the spawn pool.** The
  free-α grids **deadlock** under `fit_models`' `spawn` worker pool: all 8 workers
  drop to 0% CPU sharing one multiprocessing `pipe_handle` after a worker
  re-spawns — a spawn-under-JAX race that the heavier free-α compilation widens
  (the shared-α grids do not hit it at `n_processes=8`). Serial fitting runs the
  identical models with no pool and no deadlock. This is an experiment-harness
  workaround, not a library change; the shipped `output_activation` code is
  unaffected. (A proper fix to the spawn path is out of #277's scope — worth its
  own issue.)
- **No counts-path floor** — functional-score path only, per spec; the counts
  question is parked in a separate stub (#276). No `floor_counts` toggle added.

Everything else matches the issue body.

Yolo trail: spec gate ✓, plan gate ✓ (2 rounds), skeptic pass ✓ — full log in `_ignore/yolo/277.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
