### PR TITLE
Dashboard: quiet marimo table RPC warnings and default to 100 rows

### DIFF
--- a/experiments/dashboard.py
+++ b/experiments/dashboard.py
@@ -156,14 +156,40 @@ def _(constant_summary, display_table_df, mc, mo):
 
     _table_df = display_table_df(mc.fit_models)
 
-    ge_table = mo.ui.table(_table_df, selection="single", label="GE Landscape fit")
-    conv_table = mo.ui.table(_table_df, selection="multi", label="Convergence fits")
-    sparsity_table = mo.ui.table(_table_df, selection="multi", label="Sparsity fits")
+    ge_table = mo.ui.table(
+        _table_df,
+        selection="single",
+        label="GE Landscape fit",
+        page_size=100,
+        show_column_summaries=False,
+    )
+    conv_table = mo.ui.table(
+        _table_df,
+        selection="multi",
+        label="Convergence fits",
+        page_size=100,
+        show_column_summaries=False,
+    )
+    sparsity_table = mo.ui.table(
+        _table_df,
+        selection="multi",
+        label="Sparsity fits",
+        page_size=100,
+        show_column_summaries=False,
+    )
     corr_table = mo.ui.table(
-        _table_df, selection="multi", label="Correlation fit subset"
+        _table_df,
+        selection="multi",
+        label="Correlation fit subset",
+        page_size=100,
+        show_column_summaries=False,
     )
     scatter_table = mo.ui.table(
-        _table_df, selection="multi", label="Scatter fits (pick exactly 2)"
+        _table_df,
+        selection="multi",
+        label="Scatter fits (pick exactly 2)",
+        page_size=100,
+        show_column_summaries=False,
     )
     table_caption = mo.md(f"*{_caption}*")
     return (


### PR DESCRIPTION
## Summary

Two small, independent quality-of-life fixes to the marimo dashboard
(`experiments/dashboard.py`), both on the five fit-selection `mo.ui.table`
widgets (`ge_table`, `conv_table`, `sparsity_table`, `corr_table`,
`scatter_table`):

- **`page_size=100`** — the fit tables now show up to 100 rows per page, so the
  whole hyperparameter grid is visible at once (marimo's default was 10).
- **`show_column_summaries=False`** — the tables no longer request per-column
  summaries, so the frontend stops polling the `get_column_summaries` RPC. This
  removes the bulk of the benign `Function call not found` console warnings that
  spammed the log on every dashboard use.

## What changed vs. the plan

Matched the plan exactly: the two kwargs were added to all five fit tables, and
the three previously-one-line calls were reflowed to black-compatible multi-line
kwarg form. No other lines touched.

## Verification

- ✅ **Black clean**, **ruff clean** on `experiments/dashboard.py`.
- ✅ **Loaded a real 54-row `fit_collection.pkl`** and built both a `single`-
  and a `multi`-selection `mo.ui.table` with `page_size=100,
  show_column_summaries=False` — both construct without error.
- The console-noise reduction itself is a browser-runtime behavior and was not
  exercised headlessly; it rests on marimo's contract that
  `show_column_summaries=False` suppresses the `get_column_summaries` polling
  that produces those warnings.

## Deviations from spec

- **marimo version.** The issue stated the installed marimo was `0.22.4`; the
  env actually resolves to **`0.23.13`**. Both kwargs (`page_size`,
  `show_column_summaries`) exist and behave identically in this version, so the
  fix is unaffected — noting it only for accuracy.
- **`summary_table` (line 391) left unchanged.** Per the issue's scope decision,
  it was not touched. The runtime console check that would tell us whether it is
  a residual noise source was not run headlessly, so the conditional edit was
  not applied. If, in interactive use, `summary_table` still emits
  `get_column_summaries`/`search` warnings, add `show_column_summaries=False`
  there too (but not `page_size=100`) as a trivial follow-up.
- **`search` warnings.** As the issue's honest caveat predicted, this change
  does not disable the separate `search` RPC (no clean per-table flag exists),
  so a few residual `search` "Function call not found" lines may persist — this
  is expected and benign.
- **Manual dashboard run deferred.** The full `pixi run dashboard` browser
  walkthrough (open every tab, switch the pickle) was not executed — the
  dashboard is a blocking interactive GUI. Verification instead loaded a real
  collection and confirmed the widgets build correctly by construction.

Yolo trail: spec gate ✓, plan gate ✓ — full log in _ignore/yolo/279.log

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
