### PR TITLE
convergence-lab: beta0_ridge × sub-knee l2reg scan — a pre-registered null

### DIFF
--- a/experiments/convergence-lab/README.md
+++ b/experiments/convergence-lab/README.md
@@ -44,7 +44,36 @@ directory run `pixi run dashboard` (it discovers `fit_collection.pkl` below cwd)
   stays bounded and Huber loss barely moves). Two near-degenerate basins fit
   equally well, so noise decides which one each replicate lands in.
 - **L2 knee near `3e-4`**; double-ended degeneracy: β explodes at `l2reg=0`,
-  β collapses + α explodes at `l2reg ≥ 1e-3`.
+  β collapses + α explodes at `l2reg ≥ 1e-3`. **Below the knee, L2 is inert
+  against an active clip** (measured, #284, `cache=beta0-ridge-l2-scan`):
+  `l2reg` at 1e-8/1e-7/1e-6 — three-to-four orders under the knee — moves
+  nothing on top of `beta_clip_range=[-10,10]` across a 72-fit grid. Σβ² 0.96–1.01×
+  and α 1.00–1.11× vs the `l2reg=0` baseline, replicate-shift r within ±0.007,
+  all far under the pre-registered 2× / 0.05 effect thresholds. The clip is the
+  binding constraint on β; a whisper of L2 underneath it is a no-op. (The knee
+  is where L2 *starts* to bite — this pins the other end of that statement.)
+- **A nonzero `beta0_ridge` (1e-4…1e-2) is also inert at this fixed block**
+  (measured, #284, same grid — the axis's first sweep in this lab). **What it
+  penalizes matters and is easy to get wrong:** `_beta_ridge_penalty`
+  (`jaxmodels.py:533-540`) is NOT an intercept ridge — it penalizes each
+  non-reference condition's β0 *difference from the reference*,
+  `beta0_ridge · Σ_{d≠ref}(β0_d − β0_ref)²`, never the reference's own β0. So it
+  is an **L2 shift-shrinkage on the intercepts**, structurally parallel to
+  `fusionreg`'s L1 on the β shift — cross the two and read its effect *within*
+  each fusionreg level, never marginalized. Its penalty is also **exactly 0 at
+  initialization** wherever `beta0_init` pins all conditions to the same value
+  (as every grid here does), and only bites as the β0s separate. Effect at
+  1e-4…1e-2: α rises **monotonically** (16.1 → 16.5 → 17.5) and shift_Delta r at
+  fusionreg=0 lifts 0.594 → 0.617, so the penalty genuinely touches the optimum —
+  but every move is 1-2 orders below the effect thresholds. It is too weak to
+  matter here, not structurally dead; a stronger axis was not tested.
+- **Caveat on both of the above — they were measured where convergence was
+  already 0/8.** #284's baseline is 0/8 converged at inner maxiter=10, so that
+  grid could not have detected a convergence *gain* from any regularizer. The
+  defensible claim is *"regularization cannot rescue convergence at an
+  inadequate inner cap"*, NOT *"these regularizers are inert"* in general. #285
+  re-runs the same axes at inner maxiter=100 (the only 100%-converging cell
+  known) to separate the two.
 - **A small `l2reg>0` tames the β-explosion across the whole prod fusion axis**
   (measured, #256, `cache=l2-fusion`): at `l2reg=0` Σβ² sits at ~16–19k for
   *every* `fusionreg` (0 → 6.4e-4); `l2reg=1e-4` collapses it ~25× into the
@@ -153,6 +182,36 @@ directory run `pixi run dashboard` (it discovers `fit_collection.pkl` below cwd)
 (Append one entry per harness run: date, cache name, config swept, what the
 fit collection showed — basin diagnostics and replicate correlation computed
 downstream from a ModelCollection — the conclusion, the next step.)
+
+- 2026-07-15 | cache=beta0-ridge-l2-scan | **(#284)** sweep: `beta0_ridge` [1e-4, 1e-3, 1e-2] × `l2reg` [1e-8, 1e-7, 1e-6] × fusionreg [0.0, 4e-5, 1.6e-4, 6.4e-4], 2 reps = **72 fits**. Else `softplus-floor-off.yaml`'s fixed block VERBATIM (cold-start warmstart=false, recompute_scale=false, output_floor=null, share_alpha=true, Sigmoid, alpha_init=6, `beta_clip_range=[-10,10]` — the settled #263 bound, INHERITED not swept — `beta0_init` pins all three β0 to 0.0, scale_fusion_by_n=false, loss δ=1, outer maxiter=50/tol=1e-5, inner ge/cal maxiter=10/maxls=10/tol=1e-4), so the grid is a one-knob-at-a-time delta from its baseline (asserted in `diagnostics/test_beta0_ridge_l2_grid.py`, not eyeballed). Config: `grids/beta0-ridge-l2-scan.yaml`. Ran REMOTE on orca04 (64-core, 1.5 TB RAM, scouted idle at 0.3% CPU; GitHub reachable this time, so a real git clone at branch HEAD — no rsync fallback needed) at **n_processes=16**, wall **3320.1s (55m), 72 fit / 0 failed** (39,950s CPU-time in 3,320s wall = 12× speedup; the m100 16-worker deadlock does NOT reproduce at this grid's light inner maxiter=10 block). Downstream from `diagnostics/beta0_ridge_l2_report.py --cache beta0-ridge-l2-scan --baseline-cache 277-softplus-floor-off`.
+  **What `beta0_ridge` actually penalizes — NOT the intercepts.** `_beta_ridge_penalty` (jaxmodels.py:533-540) penalizes each non-reference condition's β0 *difference from the reference*, `beta0_ridge · Σ_{d≠ref}(β0_d − β0_ref)²`; the reference's own β0 is never touched. It is an **L2 shift-shrinkage on the intercepts**, structurally parallel to `fusionreg`'s **L1 shift penalty on the β** (`fusionreg · Σ|β_d − β_ref|`, jaxmodels.py:568-577) — hence crossing the two, and hence reading the effect WITHIN each fusionreg level rather than marginalized over it. Note the inherited `beta0_init` starts all three β0 identical at 0.0, so the penalty is **exactly 0 at initialization** and only bites as the β0s separate.
+  **Baseline computed here, not quoted — it existed nowhere.** The 277-softplus-floor-off entry says "pkl carries no converged/final_obj_err column", and the 0/16 it cites is #273's *different* free-alpha grid. Computed from the 8-fit pickle with the same report: **0/8 converged, median final_obj_err 2.29e-4, α 16.1, Σβ² 4191**. Baseline replicate-shift r — shift_Delta 0.594/0.571/0.604/0.498, shift_Omicron_BA2 0.382/0.482/0.619/0.767 across fusionreg 0/4e-5/1.6e-4/6.4e-4.
+  Convergence + basin per (beta0_ridge, l2reg), **n=8 per cell** (4 fusionreg × 2 reps); the baseline row is n=8 for its whole cache:
+    | beta0_ridge | l2reg | converged | median obj_err | α | Σβ² |
+    |---|---|---|---|---|---|
+    | *(baseline 0)* | *0* | *0/8* | *2.29e-4* | *16.1* | *4191* |
+    | 1e-4 | 1e-8 | 0/8 | 2.20e-4 | 16.1 | 4190 |
+    | 1e-4 | 1e-7 | 0/8 | 2.15e-4 | 16.1 | 4180 |
+    | 1e-4 | 1e-6 | 0/8 | 1.74e-4 | 16.3 | 4020 |
+    | 1e-3 | 1e-8 | 0/8 | 2.19e-4 | 16.5 | 4220 |
+    | 1e-3 | 1e-7 | 0/8 | 2.13e-4 | 16.5 | 4210 |
+    | 1e-3 | 1e-6 | 0/8 | 1.76e-4 | 16.7 | 4060 |
+    | 1e-2 | 1e-8 | 0/8 | 2.16e-4 | 17.5 | 4220 |
+    | 1e-2 | 1e-7 | 0/8 | 2.23e-4 | 17.6 | 4200 |
+    | 1e-2 | 1e-6 | 0/8 | 1.96e-4 | 17.8 | 4060 |
+  Replicate-shift Pearson r (rep_1 vs rep_2, `shift_*` rows only — there is no shift_Omicron_BA1, the reference carries no shift parameters), per cell across fusionreg. **Computed by slicing `mut_param_dataset_correlation` with `query=` per cell:** the bare call groups by (dataset_name, fusionreg) and mean-collapses everything else (model_collection.py:1444/787), which on this 72-fit frame would average the 9 (beta0_ridge, l2reg) fits per group — averaging away the two axes under test. Every cell reproduces the baseline column to ±0.02:
+    | beta0_ridge | mut_param | fr=0 | fr=4e-5 | fr=1.6e-4 | fr=6.4e-4 |
+    |---|---|---|---|---|---|
+    | 1e-4 | shift_Delta | 0.595 | 0.571 | 0.604 | 0.498 |
+    | 1e-3 | shift_Delta | 0.600 | 0.577 | 0.606 | 0.493 |
+    | 1e-2 | shift_Delta | 0.617 | 0.589 | 0.606 | 0.486 |
+    | 1e-4 | shift_Omicron_BA2 | 0.382 | 0.482 | 0.619 | 0.767 |
+    | 1e-3 | shift_Omicron_BA2 | 0.383 | 0.484 | 0.619 | 0.768 |
+    | 1e-2 | shift_Omicron_BA2 | 0.393 | 0.487 | 0.619 | 0.769 |
+    (l2reg collapsed above — it moves nothing; the three l2 levels agree to ±0.003 within every beta0_ridge row.)
+  **Adjudicated against #284's pre-registered thresholds** — an effect required ANY of: ≥1/8 converged where the baseline is 0/8; median final_obj_err ≥2× baseline; median shift-r moving ≥0.05; or α/Σβ² ≥2× at matched fusionreg. **Result: FLAT on all four, in all 9 cells.** Convergence 0/8 everywhere (primary DEGENERATE — 0.0 vs 0.0 discriminates nothing, so the pre-registered obj_err fallback adjudicates); obj_err ratios 0.76–0.97× (max deviation 24%, threshold 100%); α 1.00–1.11×, Σβ² 0.96–1.01×; shift-r deltas −0.006…+0.007 (threshold 0.05, so the largest is 7× under).
+  Conclusion: **NULL — neither a sub-knee `l2reg` (1e-8…1e-6) nor a nonzero `beta0_ridge` (1e-4…1e-2) buys convergence or reproducibility on top of the settled clip bound.** This CONFIRMS and sharpens the standing L2 finding: the ~3e-4 knee is real, and three-to-four orders below it the penalty is simply inert against an active `beta_clip_range=[-10,10]`, which is already the binding constraint on β. The axes are not *quite* dead, though, and the directions are informative: α rises **monotonically** with beta0_ridge (16.1 → 16.5 → 17.5 at fixed l2reg) and Σβ² dips ~4% at l2reg=1e-6, so both penalties do touch the optimum — they are 1-2 orders of magnitude too weak to move it. **The honest limit of this result:** convergence was 0/8 at the baseline BEFORE the scan began, so this grid could never have detected a convergence *gain* — it can only say the regularizers did not rescue a fit that the inner cap had already pinned. Per the 2026-07-10 maxiter-scan, the inner cap is the dominant convergence lever (0/16 → 3/16 → 12/16 over inner maxiter 1/10/100), and this grid inherits the middle-of-the-road maxiter=10. So the defensible claim is *"regularization cannot rescue convergence at an inadequate inner cap"* — NOT *"these regularizers are inert"* in general.
+  Next: **#285** (stub, blocked-by #284) re-runs these exact axes at inner maxiter=100 — the only 100%-converging cell known — which is what separates those two claims. Budget ~11h naive (m100 was 2h31m for 16 fits) and **do not reuse n_processes=16** (m100 deadlocked under it; use 4). A maxiter=100 `(0,0)` baseline does not exist yet and must be fit. Standing findings: the L2-knee finding is sharpened below; no finding is overturned.
 
 - 2026-07-10 | cache=maxiter-scan | sweep: ge/cal_kwargs `maxiter` {1, 10, 100} (COUPLED — ge and cal move together) × `recompute_scale` {False, True} × fusionreg [0.0, 4e-5, 1.6e-4, 6.4e-4], 2 reps = 48 fits. Else #277 softplus-floor-off.yaml fixed block VERBATIM (cold-start warmstart=False, output_floor=null, share_alpha=true, Sigmoid, l2reg=0, alpha_init=6, beta_clip_range=[-10,10], loss δ=1, outer maxiter=50/tol=1e-5, inner maxls=10/tol=1e-4). Configs: grids/maxiter-scan-m{1,10,100}.yaml (three configs because the harness Cartesian-products every sweep axis — ge_kwargs and cal_kwargs listed together would 3×3-cross to 9, not the 3 coupled cells; one config per level then `pd.concat` the three fit_collection.pkl). Ran REMOTE on orca04 (64-core, scouted idle) — source tree rsync'd to HEAD 9121748 (GitHub unreachable from orca04 via the 1Password-gated forwarded agent, so no remote git fetch; the one required data CSV, gitignored, rsync'd explicitly). m1/m10 fit at n_processes=16 (wall 154s / 639s, 16 fit 0 failed each); **m100 deadlocked under the 16-worker spawn pool** (collapsed to a single limping process, ~46 min no output — the documented spawn-under-JAX race, widened by the heavier 100-iter compile) → rerun at **n_processes=4**, which ran clean (4 workers ~100% CPU each), wall 9049s (2h31m), 16 fit 0 failed. Downstream basin/convergence computed inline from the combined frame.
   Convergence rate + basin (α, Σβ² of ref-condition β, mean fit_time) per (ge/cal maxiter × recompute_scale):

--- a/experiments/convergence-lab/diagnostics/beta0_ridge_l2_report.py
+++ b/experiments/convergence-lab/diagnostics/beta0_ridge_l2_report.py
@@ -186,23 +186,58 @@ def replicate_corr_table(frame: pd.DataFrame) -> pd.DataFrame:
     return pd.concat(out, ignore_index=True) if out else pd.DataFrame()
 
 
-def _load(cache: str) -> pd.DataFrame:
+def shift_corr_pivot(corr: pd.DataFrame) -> pd.DataFrame:
+    """The ``shift_*`` rows of :func:`replicate_corr_table`, pivoted by fusionreg.
+
+    ``mut_param_dataset_correlation`` returns a row per mutation-parameter type
+    (``beta_*``, ``shift_*``, ``predicted_func_score_*``). The #284
+    reproducibility criterion is the **shift** rows specifically — the
+    condition-vs-reference parameters the fusion lasso penalizes. Note there is
+    no ``shift_Omicron_BA1``: it is the reference condition and carries no shift
+    parameters, so only ``shift_Delta`` and ``shift_Omicron_BA2`` exist.
+
+    Args:
+        corr: Output of :func:`replicate_corr_table`.
+
+    Returns:
+        A ``(beta0_ridge, l2reg, mut_param)`` × ``fusionreg`` pivot of Pearson
+        r, or an empty frame if ``corr`` carries no ``shift_*`` rows.
+    """
+    if not len(corr):
+        return pd.DataFrame()
+    shifts = corr[corr["mut_param"].str.startswith("shift_")]
+    if not len(shifts):
+        return pd.DataFrame()
+    return shifts.pivot_table(
+        index=["beta0_ridge", "l2reg", "mut_param"],
+        columns="fusionreg",
+        values="correlation",
+    ).reset_index()
+
+
+def _load(cache: str, results_dir: Path | None = None) -> pd.DataFrame:
     """Load one cache's fit-collection frame.
 
     Args:
-        cache: Subdir under ``results/`` holding ``fit_collection.pkl``.
+        cache: Subdir under the results dir holding ``fit_collection.pkl``.
+        results_dir: Directory holding the caches. ``None`` → the harness's
+            own ``RESULTS_DIR``, which resolves relative to *this file*. That
+            default is wrong when the script runs from a worktree: ``results/``
+            is gitignored and materializes only in the canonical clone, so pass
+            ``--results-dir`` there.
 
     Returns:
         The raw fit-collection DataFrame.
     """
-    pkl = harness.RESULTS_DIR / cache / "fit_collection.pkl"
+    base = results_dir if results_dir is not None else harness.RESULTS_DIR
+    pkl = Path(base) / cache / "fit_collection.pkl"
     frame = pickle.load(open(pkl, "rb"))
     size_gb = pkl.stat().st_size / 1e9
     print(f"[report] loaded {len(frame)} fits from {pkl} ({size_gb:.1f} GB)")
     return frame
 
 
-def _report(cache: str, label: str) -> None:
+def _report(cache: str, label: str, results_dir: Path | None = None) -> None:
     """Load one cache, print its tables, and drop the frame before returning.
 
     Loads inside the call rather than taking a frame, so the caller never holds
@@ -211,18 +246,22 @@ def _report(cache: str, label: str) -> None:
     ~0.7 GB, so holding both would peak near 7 GB for no reason.
 
     Args:
-        cache: Subdir under ``results/`` holding ``fit_collection.pkl``.
+        cache: Subdir under the results dir holding ``fit_collection.pkl``.
         label: Human-readable name for the section headers.
+        results_dir: Passed through to :func:`_load`.
     """
-    frame = _load(cache)
+    frame = _load(cache, results_dir)
     basin = basin_table(frame)
     with pd.option_context("display.width", 200, "display.max_rows", 100):
         print(f"\n=== [{label}] convergence + basin per (beta0_ridge, l2reg) ===")
         print(convergence_table(basin).to_string(index=False))
         print(f"\n=== [{label}] basin diagnostics (per fit) ===")
         print(basin.to_string(index=False))
-        print(f"\n=== [{label}] replicate-shift Pearson r (per cell slice) ===")
         corr = replicate_corr_table(frame)
+        print(f"\n=== [{label}] replicate-SHIFT Pearson r — the #284 criterion ===")
+        pivot = shift_corr_pivot(corr)
+        print(pivot.to_string(index=False) if len(pivot) else "(no shift_* rows)")
+        print(f"\n=== [{label}] all mut_param correlations (per cell slice) ===")
         print(corr.to_string(index=False) if len(corr) else "(no ≥2-dataset slice)")
 
     # Drop the collection (and its fitted models) before the caller loads the
@@ -246,11 +285,21 @@ def main() -> None:
         help="optional (0,0) baseline cache to report alongside "
         "(e.g. 277-softplus-floor-off)",
     )
+    ap.add_argument(
+        "--results-dir",
+        default=None,
+        type=Path,
+        help="directory holding the caches (default: the harness's results/, "
+        "resolved next to harness.py). results/ is gitignored and exists only "
+        "in the canonical clone, so pass this when running from a worktree.",
+    )
     args = ap.parse_args()
 
-    _report(args.cache, args.cache)
+    _report(args.cache, args.cache, args.results_dir)
     if args.baseline_cache:
-        _report(args.baseline_cache, f"BASELINE {args.baseline_cache}")
+        _report(
+            args.baseline_cache, f"BASELINE {args.baseline_cache}", args.results_dir
+        )
 
 
 if __name__ == "__main__":

--- a/experiments/convergence-lab/diagnostics/beta0_ridge_l2_report.py
+++ b/experiments/convergence-lab/diagnostics/beta0_ridge_l2_report.py
@@ -1,0 +1,257 @@
+r"""Downstream report for the beta0_ridge × sub-knee l2reg scan (#284).
+
+Loads a convergence-lab ``fit_collection.pkl`` into a ``ModelCollection`` and
+prints, per ``(beta0_ridge, l2reg)`` cell: the convergence rate, median
+``final_obj_err``, basin diagnostics (Σβ², α), and replicate-shift Pearson r.
+With ``--baseline-cache`` it prints the same tables for the ``(0,0)`` baseline
+so the two are read side by side — the baseline's convergence rate has never
+been computed and cannot be quoted from the README.
+
+Reuses ``l2_fusion_report.basin_row`` UNCHANGED (its contract is pinned by
+``test_l2_fusion_report.py``) and adds the ``beta0_ridge`` column this grid
+needs, mirroring how ``beta_control_report`` bolts on its ``arm`` column.
+
+Adjudication (pre-registered in #284) — an axis shows an effect if any of:
+
+* convergence: ≥1/8 converged in a cell where the baseline is 0/8;
+* fallback:    median ``final_obj_err`` differing ≥2× from baseline;
+* repro:       median replicate-r shifting ≥0.05 vs baseline;
+* basin:       Σβ² or α differing ≥2× at matched ``fusionreg``.
+
+The primary is expected to be DEGENERATE (0/72 vs 0/8) — when it is, the
+``final_obj_err`` fallback IS the adjudicator, not a footnote.
+
+Run::
+
+    pixi run python experiments/convergence-lab/diagnostics/beta0_ridge_l2_report.py \\
+        --cache beta0-ridge-l2-scan --baseline-cache 277-softplus-floor-off
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import os
+import pickle
+import sys
+import warnings
+from pathlib import Path
+
+os.environ.setdefault("XLA_FLAGS", "--xla_cpu_multi_thread_eigen=false")
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
+
+warnings.filterwarnings("ignore")
+
+import pandas as pd  # noqa: E402
+
+# Reuse the harness's RESULTS_DIR and the l2-fusion report's basin_row.
+sys.path.insert(0, str(Path(os.path.abspath(__file__)).parent.parent))
+import harness  # noqa: E402
+
+sys.path.insert(0, str(Path(os.path.abspath(__file__)).parent))
+import l2_fusion_report as l2rpt  # noqa: E402
+
+from multidms.model_collection import ModelCollection  # noqa: E402
+
+
+def basin_row_with_ridge(fit) -> dict:
+    """``l2_fusion_report.basin_row`` plus the ``beta0_ridge`` cell value.
+
+    ``basin_row`` predates this grid's ``beta0_ridge`` axis and does not carry
+    it. Rather than edit it (its contract is pinned by
+    ``test_l2_fusion_report.py``), bolt the column on here — the same move
+    ``beta_control_report.basin_table`` makes for its ``arm`` column.
+
+    Args:
+        fit: A row (``pd.Series``) of the fit-collection frame.
+
+    Returns:
+        ``basin_row``'s dict plus ``beta0_ridge``.
+    """
+    row = l2rpt.basin_row(fit)
+    row["beta0_ridge"] = fit.beta0_ridge
+    return row
+
+
+def basin_table(frame: pd.DataFrame) -> pd.DataFrame:
+    """Per-fit basin diagnostics, sorted with ``beta0_ridge`` outermost.
+
+    ``l2_fusion_report.basin_table`` sorts by ``(l2reg, fusionreg,
+    dataset_name)`` and knows nothing of ``beta0_ridge``, so this grid needs its
+    own.
+
+    Args:
+        frame: The raw fit-collection DataFrame.
+
+    Returns:
+        One row per fit, sorted by
+        ``(beta0_ridge, l2reg, fusionreg, dataset_name)``.
+    """
+    rows = [basin_row_with_ridge(frame.iloc[i]) for i in range(len(frame))]
+    return (
+        pd.DataFrame(rows)
+        .sort_values(["beta0_ridge", "l2reg", "fusionreg", "dataset_name"])
+        .reset_index(drop=True)
+    )
+
+
+def convergence_table(basin: pd.DataFrame) -> pd.DataFrame:
+    """Convergence rate + median diagnostics per ``(beta0_ridge, l2reg)`` cell.
+
+    The denominator is explicit: each cell holds ``n`` fits (4 ``fusionreg`` × 2
+    replicates = 8 for the full grid). ``median_obj_err`` is the pre-registered
+    fallback adjudicator for when ``conv_rate`` is degenerate (all-zero) — the
+    lab has repeatedly found the binary flag untrustworthy while
+    ``final_obj_err`` stays tiny and informative (#273: 0/16 converged, obj_err
+    ≤3e-4, parameters trustworthy).
+
+    Args:
+        basin: Output of :func:`basin_table`.
+
+    Returns:
+        One row per ``(beta0_ridge, l2reg)``: ``n``, ``n_converged``,
+        ``conv_rate``, ``median_obj_err``, ``median_alpha``,
+        ``median_sum_beta_sq``.
+    """
+    out = (
+        basin.groupby(["beta0_ridge", "l2reg"], dropna=False)
+        .agg(
+            n=("converged", "size"),
+            n_converged=("converged", "sum"),
+            median_obj_err=("final_obj_err", "median"),
+            median_alpha=("alpha", "median"),
+            median_sum_beta_sq=("sum_beta_sq", "median"),
+        )
+        .reset_index()
+    )
+    out["conv_rate"] = out["n_converged"] / out["n"]
+    return out[
+        [
+            "beta0_ridge",
+            "l2reg",
+            "n",
+            "n_converged",
+            "conv_rate",
+            "median_obj_err",
+            "median_alpha",
+            "median_sum_beta_sq",
+        ]
+    ]
+
+
+def replicate_corr_table(frame: pd.DataFrame) -> pd.DataFrame:
+    """Replicate-shift Pearson r across fusionreg, per ``(beta0_ridge, l2reg)``.
+
+    ``mut_param_dataset_correlation`` forwards to ``split_apply_combine_muts``
+    with ``groupby=("dataset_name", x)`` (``model_collection.py:1443-1445``) and
+    mean-collapses every other column (``aggregate_func="mean"``). On this
+    72-fit frame each ``(rep, fusionreg)`` group holds 9 fits (3 ``beta0_ridge``
+    × 3 ``l2reg``), so the BARE call would average away the two axes under test
+    and return a spuriously smooth r. Slicing with ``query=`` per cell is the
+    fix — the same move ``l2_fusion_report.replicate_corr_table`` makes for its
+    single ``l2reg`` loop, extended here to the nested pair.
+
+    Each slice holds 2 datasets × 4 ``fusionreg`` = 8 fits, clearing the
+    ``<2 datasets`` guard at ``model_collection.py:1440``. The correlated
+    population is ``rep_1`` vs ``rep_2``; ``inner_merge_dataset_muts`` (default
+    True) restricts to mutations shared across both.
+
+    Args:
+        frame: The raw fit-collection DataFrame.
+
+    Returns:
+        Concatenated per-slice correlation frames (columns ``datasets``,
+        ``mut_param``, ``correlation``, ``fusionreg``, plus ``beta0_ridge`` and
+        ``l2reg`` tags), or an empty frame if no slice has ≥2 datasets.
+    """
+    mc = ModelCollection(frame)
+    out = []
+    for b in sorted(frame["beta0_ridge"].unique()):
+        for l2 in sorted(frame["l2reg"].unique()):
+            try:
+                _, df = mc.mut_param_dataset_correlation(
+                    x="fusionreg",
+                    return_data=True,
+                    r=1,
+                    query=f"beta0_ridge == {b} and l2reg == {l2}",
+                )
+            except ValueError:
+                # Fewer than 2 datasets in this slice — skip it honestly.
+                continue
+            df = df.copy()
+            df["beta0_ridge"] = b
+            df["l2reg"] = l2
+            out.append(df)
+    return pd.concat(out, ignore_index=True) if out else pd.DataFrame()
+
+
+def _load(cache: str) -> pd.DataFrame:
+    """Load one cache's fit-collection frame.
+
+    Args:
+        cache: Subdir under ``results/`` holding ``fit_collection.pkl``.
+
+    Returns:
+        The raw fit-collection DataFrame.
+    """
+    pkl = harness.RESULTS_DIR / cache / "fit_collection.pkl"
+    frame = pickle.load(open(pkl, "rb"))
+    size_gb = pkl.stat().st_size / 1e9
+    print(f"[report] loaded {len(frame)} fits from {pkl} ({size_gb:.1f} GB)")
+    return frame
+
+
+def _report(cache: str, label: str) -> None:
+    """Load one cache, print its tables, and drop the frame before returning.
+
+    Loads inside the call rather than taking a frame, so the caller never holds
+    two collections at once. These pickles carry the fitted models themselves at
+    a measured ~88 MB/fit — the 72-fit scan is ~6.3 GB and the 8-fit baseline
+    ~0.7 GB, so holding both would peak near 7 GB for no reason.
+
+    Args:
+        cache: Subdir under ``results/`` holding ``fit_collection.pkl``.
+        label: Human-readable name for the section headers.
+    """
+    frame = _load(cache)
+    basin = basin_table(frame)
+    with pd.option_context("display.width", 200, "display.max_rows", 100):
+        print(f"\n=== [{label}] convergence + basin per (beta0_ridge, l2reg) ===")
+        print(convergence_table(basin).to_string(index=False))
+        print(f"\n=== [{label}] basin diagnostics (per fit) ===")
+        print(basin.to_string(index=False))
+        print(f"\n=== [{label}] replicate-shift Pearson r (per cell slice) ===")
+        corr = replicate_corr_table(frame)
+        print(corr.to_string(index=False) if len(corr) else "(no ≥2-dataset slice)")
+
+    # Drop the collection (and its fitted models) before the caller loads the
+    # next one — see the docstring's size note.
+    del frame
+    gc.collect()
+
+
+def main() -> None:
+    """CLI: ``--cache`` (+ optional ``--baseline-cache``) → print all tables."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--cache",
+        default="beta0-ridge-l2-scan",
+        help="results subdir holding fit_collection.pkl "
+        "(default: beta0-ridge-l2-scan)",
+    )
+    ap.add_argument(
+        "--baseline-cache",
+        default=None,
+        help="optional (0,0) baseline cache to report alongside "
+        "(e.g. 277-softplus-floor-off)",
+    )
+    args = ap.parse_args()
+
+    _report(args.cache, args.cache)
+    if args.baseline_cache:
+        _report(args.baseline_cache, f"BASELINE {args.baseline_cache}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/convergence-lab/diagnostics/beta0_ridge_l2_report.py
+++ b/experiments/convergence-lab/diagnostics/beta0_ridge_l2_report.py
@@ -241,9 +241,11 @@ def _report(cache: str, label: str, results_dir: Path | None = None) -> None:
     """Load one cache, print its tables, and drop the frame before returning.
 
     Loads inside the call rather than taking a frame, so the caller never holds
-    two collections at once. These pickles carry the fitted models themselves at
-    a measured ~88 MB/fit — the 72-fit scan is ~6.3 GB and the 8-fit baseline
-    ~0.7 GB, so holding both would peak near 7 GB for no reason.
+    two collections at once. These pickles carry the fitted models themselves:
+    ~88 MB/fit on disk but a measured **~213 MB/fit resident**, so the 72-fit
+    scan alone peaks near 15 GB. Holding the baseline alongside it would add
+    ~1.7 GB alongside for no reason, and on a 39 GB laptop that headroom is
+    worth keeping.
 
     Args:
         cache: Subdir under the results dir holding ``fit_collection.pkl``.

--- a/experiments/convergence-lab/diagnostics/beta0_ridge_l2_report.py
+++ b/experiments/convergence-lab/diagnostics/beta0_ridge_l2_report.py
@@ -144,7 +144,7 @@ def replicate_corr_table(frame: pd.DataFrame) -> pd.DataFrame:
     """Replicate-shift Pearson r across fusionreg, per ``(beta0_ridge, l2reg)``.
 
     ``mut_param_dataset_correlation`` forwards to ``split_apply_combine_muts``
-    with ``groupby=("dataset_name", x)`` (``model_collection.py:1443-1445``) and
+    with ``groupby=("dataset_name", x)`` (``model_collection.py:1444``) and
     mean-collapses every other column (``aggregate_func="mean"``). On this
     72-fit frame each ``(rep, fusionreg)`` group holds 9 fits (3 ``beta0_ridge``
     × 3 ``l2reg``), so the BARE call would average away the two axes under test

--- a/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_grid.py
+++ b/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_grid.py
@@ -5,6 +5,7 @@ report tests, which need a fit collection). Guards the two things the #284
 acceptance criteria pin: the cell count and the inherited clip bound.
 """
 
+import math
 import os
 import sys
 from pathlib import Path
@@ -46,6 +47,31 @@ def test_grid_inherits_the_clip_bound():
     assert config["fixed"]["output_floor"] is None
     assert config["fixed"]["share_alpha"] is True
     assert config["fixed"]["recompute_scale"] is False
+
+
+def test_build_params_preserves_both_new_axes():
+    """The swept axes survive build_params' distinct-value collapse.
+
+    ``explode_grid`` proving 72 cells is not enough: ``build_params`` re-collects
+    each kwarg's distinct values into a list for ``fit_models`` to re-cross
+    (``harness.py:210-218``), and that collapse is what actually reaches the
+    fitter. A float axis that collapsed wrong would silently shrink the grid.
+    """
+    import harness
+
+    config = harness.load_config(GRID)
+    cells = harness.explode_grid(config)
+    params = harness.build_params(cells, {"rep_1": "DATA1", "rep_2": "DATA2"})
+
+    assert params["beta0_ridge"] == [1.0e-4, 1.0e-3, 1.0e-2]
+    assert params["l2reg"] == [1.0e-8, 1.0e-7, 1.0e-6]
+    assert params["fusionreg"] == [0.0, 4.0e-5, 1.6e-4, 6.4e-4]
+    assert len(params["dataset"]) == 2
+
+    n_fits = len(params["dataset"]) * math.prod(
+        len(v) for k, v in params.items() if k != "dataset"
+    )
+    assert n_fits == 72, f"fit_models would fit {n_fits}, not 72"
 
 
 def test_grid_matches_the_baseline_fixed_block():

--- a/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_grid.py
+++ b/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_grid.py
@@ -1,0 +1,71 @@
+"""Grid-config test: the beta0_ridge × l2reg scan expands to exactly 72 cells (#284).
+
+Pure config validation — no fitting, no pickle, so this always runs (unlike the
+report tests, which need a fit collection). Guards the two things the #284
+acceptance criteria pin: the cell count and the inherited clip bound.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+DIAG = Path(__file__).resolve().parent
+sys.path.insert(0, str(DIAG.parent))
+
+os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
+
+GRID = DIAG.parent / "grids" / "beta0-ridge-l2-scan.yaml"
+
+
+def test_grid_expands_to_72_cells():
+    """4 fusionreg × 3 beta0_ridge × 3 l2reg × 2 replicates = 72 fits."""
+    import harness
+
+    config = harness.load_config(GRID)
+    cells = harness.explode_grid(config)
+    assert len(cells) == 72, f"expected 72 cells, got {len(cells)}"
+
+
+def test_grid_sweeps_the_three_axes():
+    """The three swept axes carry exactly the specified values."""
+    import harness
+
+    config = harness.load_config(GRID)
+    assert config["sweep"]["fusionreg"] == [0.0, 4.0e-5, 1.6e-4, 6.4e-4]
+    assert config["sweep"]["beta0_ridge"] == [1.0e-4, 1.0e-3, 1.0e-2]
+    assert config["sweep"]["l2reg"] == [1.0e-8, 1.0e-7, 1.0e-6]
+    assert config["replicates"] == [1, 2]
+
+
+def test_grid_inherits_the_clip_bound():
+    """The #263 clip bound and the baseline's regime flags are inherited verbatim."""
+    import harness
+
+    config = harness.load_config(GRID)
+    assert config["fixed"]["beta_clip_range"] == [-10, 10]
+    assert config["fixed"]["output_floor"] is None
+    assert config["fixed"]["share_alpha"] is True
+    assert config["fixed"]["recompute_scale"] is False
+
+
+def test_grid_matches_the_baseline_fixed_block():
+    """Every fixed key equals softplus-floor-off's, minus the two swept axes.
+
+    This is the #284 AC1 check in executable form: the grid must be a
+    one-knob-at-a-time delta from its baseline, so any drift in the inherited
+    block is a bug, not a choice.
+    """
+    import harness
+
+    baseline = harness.load_config(DIAG.parent / "grids" / "softplus-floor-off.yaml")
+    scan = harness.load_config(GRID)
+
+    moved = {"l2reg", "beta0_ridge"}
+    assert moved <= set(baseline["fixed"]), "baseline should fix the axes we sweep"
+    assert moved <= set(scan["sweep"]), "scan should sweep them"
+    assert not (moved & set(scan["fixed"])), "scan must not also fix them"
+
+    expected_fixed = {k: v for k, v in baseline["fixed"].items() if k not in moved}
+    assert scan["fixed"] == expected_fixed, "inherited fixed block drifted"
+    assert scan["sweep"]["fusionreg"] == baseline["sweep"]["fusionreg"]
+    assert scan["replicates"] == baseline["replicates"]

--- a/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_report.py
+++ b/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_report.py
@@ -91,6 +91,60 @@ def test_convergence_table_reports_a_degenerate_rate_honestly():
     assert out["median_obj_err"].notna().all(), "fallback must survive a 0/n rate"
 
 
+def test_shift_corr_pivot_keeps_only_shift_rows():
+    """shift_corr_pivot drops beta_*/predicted_* and pivots shift_* by fusionreg.
+
+    The real correlation frame carries a row per mutation-parameter type; #284's
+    reproducibility criterion is the shift_* rows only. Synthetic — always runs.
+    """
+    import beta0_ridge_l2_report as rpt
+
+    corr = pd.DataFrame(
+        [
+            {
+                "datasets": "rep_1,rep_2",
+                "mut_param": mp,
+                "correlation": 0.5,
+                "fusionreg": f,
+                "beta0_ridge": 1e-4,
+                "l2reg": 1e-8,
+            }
+            for mp in (
+                "beta_Delta",
+                "shift_Delta",
+                "predicted_func_score_Delta",
+                "shift_Omicron_BA2",
+            )
+            for f in (0.0, 6.4e-4)
+        ]
+    )
+    out = rpt.shift_corr_pivot(corr)
+    assert len(out) == 2, "only shift_Delta and shift_Omicron_BA2 survive"
+    assert set(out["mut_param"]) == {"shift_Delta", "shift_Omicron_BA2"}
+    for col in (0.0, 6.4e-4):
+        assert col in out.columns, f"fusionreg {col} should be a pivoted column"
+
+
+def test_shift_corr_pivot_handles_empty_input():
+    """An empty or shift-less correlation frame yields an empty pivot, not a raise."""
+    import beta0_ridge_l2_report as rpt
+
+    assert not len(rpt.shift_corr_pivot(pd.DataFrame()))
+    beta_only = pd.DataFrame(
+        [
+            {
+                "datasets": "rep_1,rep_2",
+                "mut_param": "beta_Delta",
+                "correlation": 0.5,
+                "fusionreg": 0.0,
+                "beta0_ridge": 1e-4,
+                "l2reg": 1e-8,
+            }
+        ]
+    )
+    assert not len(rpt.shift_corr_pivot(beta_only))
+
+
 @pytest.mark.skipif(
     _sample_pickle() is None,
     reason="needs a sample fit_collection.pkl (set BETA0_RIDGE_TEST_PKL)",

--- a/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_report.py
+++ b/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_report.py
@@ -1,0 +1,133 @@
+"""Tests for the beta0_ridge × l2reg report's extraction and grouping (#284)."""
+
+import os
+import pickle
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+DIAG = Path(__file__).resolve().parent
+sys.path.insert(0, str(DIAG))
+
+
+def _sample_pickle():
+    """Locate a sample fit_collection.pkl to extract from.
+
+    ``results/`` is gitignored and never materialized in a worktree, so honor a
+    ``BETA0_RIDGE_TEST_PKL`` override (point it at the canonical clone's copy);
+    otherwise fall back to the in-tree baseline cache. Returns ``None`` when no
+    fixture is reachable, so the test skips rather than fails.
+    """
+    override = os.environ.get("BETA0_RIDGE_TEST_PKL")
+    if override and Path(override).exists():
+        return Path(override)
+    in_tree = DIAG.parent / "results" / "277-softplus-floor-off" / "fit_collection.pkl"
+    return in_tree if in_tree.exists() else None
+
+
+def _synthetic_basin() -> pd.DataFrame:
+    """A basin frame with a known answer: 4 cells × 4 fits, half converged.
+
+    2 beta0_ridge × 2 l2reg × 2 fusionreg × 2 replicates = 16 rows. Exactly one
+    replicate per cell converges, so every cell's rate must be 0.5.
+    """
+    return pd.DataFrame(
+        [
+            {
+                "beta0_ridge": b,
+                "l2reg": l2,
+                "fusionreg": f,
+                "dataset_name": d,
+                "sum_beta_sq": 100.0,
+                "alpha": 5.0,
+                "converged": conv,
+                "final_obj_err": 1e-4,
+            }
+            for b in (1e-4, 1e-3)
+            for l2 in (1e-8, 1e-7)
+            for f in (0.0, 6.4e-4)
+            for d, conv in (("rep_1", True), ("rep_2", False))
+        ]
+    )
+
+
+def test_convergence_table_groups_by_both_axes():
+    """convergence_table yields one row per (beta0_ridge, l2reg) with a rate.
+
+    Uses a synthetic basin frame — no pickle needed, so this always runs.
+    """
+    import beta0_ridge_l2_report as rpt
+
+    out = rpt.convergence_table(_synthetic_basin())
+    assert len(out) == 4, "2 beta0_ridge × 2 l2reg = 4 cells"
+    assert set(out.columns) >= {
+        "beta0_ridge",
+        "l2reg",
+        "n",
+        "n_converged",
+        "conv_rate",
+        "median_obj_err",
+    }
+    assert (out["n"] == 4).all(), "each cell holds 2 fusionreg × 2 reps = 4 fits"
+    assert (out["conv_rate"] == 0.5).all(), "1 of 2 reps converged per cell"
+
+
+def test_convergence_table_reports_a_degenerate_rate_honestly():
+    """An all-unconverged grid yields conv_rate 0.0 with a finite median obj_err.
+
+    This is the expected real-world case (#284 pre-registers a likely 0/72), and
+    it is exactly when the median_obj_err fallback becomes the adjudicator — so
+    the fallback column must still carry a real number when the rate is
+    degenerate.
+    """
+    import beta0_ridge_l2_report as rpt
+
+    basin = _synthetic_basin()
+    basin["converged"] = False
+    out = rpt.convergence_table(basin)
+    assert (out["conv_rate"] == 0.0).all(), "degenerate rate reported as 0.0"
+    assert out["median_obj_err"].notna().all(), "fallback must survive a 0/n rate"
+
+
+@pytest.mark.skipif(
+    _sample_pickle() is None,
+    reason="needs a sample fit_collection.pkl (set BETA0_RIDGE_TEST_PKL)",
+)
+def test_basin_row_with_ridge_adds_beta0_ridge():
+    """basin_row_with_ridge returns basin_row's keys plus beta0_ridge."""
+    import beta0_ridge_l2_report as rpt
+
+    frame = pickle.load(open(_sample_pickle(), "rb"))
+    out = rpt.basin_row_with_ridge(frame.iloc[0])
+    assert "beta0_ridge" in out
+    for key in (
+        "l2reg",
+        "fusionreg",
+        "dataset_name",
+        "sum_beta_sq",
+        "alpha",
+        "converged",
+        "final_obj_err",
+    ):
+        assert key in out, f"lost {key} from basin_row's contract"
+    assert out["sum_beta_sq"] >= 0.0
+    assert isinstance(out["converged"], bool)
+
+
+@pytest.mark.skipif(
+    _sample_pickle() is None,
+    reason="needs a sample fit_collection.pkl (set BETA0_RIDGE_TEST_PKL)",
+)
+def test_basin_table_sorts_by_beta0_ridge_first():
+    """basin_table sorts by (beta0_ridge, l2reg, fusionreg, dataset_name)."""
+    import beta0_ridge_l2_report as rpt
+
+    frame = pickle.load(open(_sample_pickle(), "rb"))
+    table = rpt.basin_table(frame)
+    assert len(table) == len(frame)
+    expected = table.sort_values(
+        ["beta0_ridge", "l2reg", "fusionreg", "dataset_name"]
+    ).reset_index(drop=True)
+    pd.testing.assert_frame_equal(table, expected)

--- a/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_report.py
+++ b/experiments/convergence-lab/diagnostics/test_beta0_ridge_l2_report.py
@@ -91,6 +91,47 @@ def test_convergence_table_reports_a_degenerate_rate_honestly():
     assert out["median_obj_err"].notna().all(), "fallback must survive a 0/n rate"
 
 
+def test_basin_table_sort_order_without_a_pickle(monkeypatch):
+    """basin_table sorts beta0_ridge-outermost — checked without a fit collection.
+
+    The pickle-backed sort test skips on a fresh checkout (results/ is
+    gitignored), so the sort contract would go unverified exactly where it is
+    most likely to regress. Stub the per-row extraction to cover the ordering on
+    synthetic rows, which is all the sort itself depends on.
+    """
+    import beta0_ridge_l2_report as rpt
+
+    rows = [
+        {
+            "beta0_ridge": b,
+            "l2reg": l2,
+            "fusionreg": f,
+            "dataset_name": d,
+            "sum_beta_sq": 1.0,
+            "alpha": 1.0,
+            "converged": False,
+            "final_obj_err": 1e-4,
+        }
+        # Deliberately shuffled relative to the expected sort order.
+        for b in (1e-2, 1e-4)
+        for l2 in (1e-6, 1e-8)
+        for f in (6.4e-4, 0.0)
+        for d in ("rep_2", "rep_1")
+    ]
+    frame = pd.DataFrame(rows)
+    monkeypatch.setattr(
+        rpt, "basin_row_with_ridge", lambda fit: dict(fit), raising=True
+    )
+
+    table = rpt.basin_table(frame)
+    keys = ["beta0_ridge", "l2reg", "fusionreg", "dataset_name"]
+    assert table[keys].values.tolist() == (
+        frame.sort_values(keys).reset_index(drop=True)[keys].values.tolist()
+    )
+    # The outermost key really is beta0_ridge, not l2reg (the prior art's order).
+    assert table["beta0_ridge"].is_monotonic_increasing
+
+
 def test_shift_corr_pivot_keeps_only_shift_rows():
     """shift_corr_pivot drops beta_*/predicted_* and pivots shift_* by fusionreg.
 

--- a/experiments/convergence-lab/grids/beta0-ridge-l2-scan.yaml
+++ b/experiments/convergence-lab/grids/beta0-ridge-l2-scan.yaml
@@ -1,0 +1,36 @@
+# beta0_ridge × sub-knee l2reg scan (#284) — does a whisper of L2 (three-to-four
+# orders below the measured ~3e-4 knee) or a nonzero beta0_ridge buy convergence
+# or replicate reproducibility ON TOP OF the settled beta_clip_range=[-10,10]
+# bound (#263)? Baseline = the separately-fit (l2reg=0, beta0_ridge=0) cache
+# `277-softplus-floor-off`, whose fixed block this inherits VERBATIM except for
+# the two axes below moving fixed: -> sweep:.
+#
+# NOTE beta0_ridge does NOT penalize the intercepts — it penalizes each
+# non-reference condition's β0 DIFFERENCE from the reference, (β0_d − β0_ref)²
+# (jaxmodels.py:533-540). It is an L2 shift-shrinkage, structurally parallel to
+# fusionreg's L1 on the β shift — hence crossing both axes here. Its penalty is
+# also exactly 0 at initialization (beta0_init pins all three conditions to 0.0)
+# and only bites as the β0s separate during fitting.
+#
+# 4 fusionreg × 3 beta0_ridge × 3 l2reg × 2 reps = 72 fits.
+sweep:
+  fusionreg: [0.0, 4.0e-5, 1.6e-4, 6.4e-4]      # same 4-point axis as #274/#277
+  beta0_ridge: [1.0e-4, 1.0e-3, 1.0e-2]         # NEW axis — never swept in this lab
+  l2reg: [1.0e-8, 1.0e-7, 1.0e-6]               # NEW axis — all sub-knee (knee ~3e-4)
+fixed:
+  output_floor: null                            # OFF — matches the baseline cache
+  share_alpha: true                             # #274 baseline (shared-α) condition
+  # --- softplus-floor-off.yaml fixed block, VERBATIM minus the two swept axes ---
+  warmstart: false
+  recompute_scale: false
+  ge_type: Sigmoid
+  scale_fusion_by_n: false
+  alpha_init: 6.0
+  beta0_init: {Omicron_BA1: 0.0, Delta: 0.0, Omicron_BA2: 0.0}
+  beta_clip_range: [-10, 10]                    # settled β-bound (#263) — inherited
+  loss_kwargs: {δ: 1.0}
+  maxiter: 50                                   # outer block cap
+  tol: 1.0e-5                                   # outer tol
+  ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+  cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
+replicates: [1, 2]


### PR DESCRIPTION
Closes #284

Adds a 72-fit convergence-lab grid crossing `beta0_ridge [1e-4, 1e-3, 1e-2]` × sub-knee `l2reg [1e-8, 1e-7, 1e-6]` × `fusionreg [0, 4e-5, 1.6e-4, 6.4e-4]` × 2 reps, on top of the settled `beta_clip_range=[-10,10]` bound, plus the report script that adjudicates it.

## Result — a pre-registered null, flat on all four criteria

**Neither axis buys convergence or reproducibility on top of the settled clip bound.** 72 fits, 0 failed. All 9 `(beta0_ridge, l2reg)` cells read flat against every threshold #284 registered *before* the run:

| Criterion | Threshold | Measured | |
|---|---|---|---|
| Convergence (primary) | ≥1/8 where baseline is 0/8 | **0/8 in all 9 cells** | ✗ flat — and **degenerate** |
| Convergence (fallback) | median `final_obj_err` ≥2× | 0.76–0.97× | ✗ flat |
| Basin | α or Σβ² ≥2× | α 1.00–1.11×, Σβ² 0.96–1.01× | ✗ flat |
| Reproducibility | median shift-r moves ≥0.05 | −0.006 … +0.007 | ✗ flat (7× under) |

**The primary metric is degenerate, and that was anticipated.** The baseline is *also* 0/8, so "0.0 vs 0.0" discriminates nothing — which is exactly why `median_obj_err` was pre-registered as the fallback adjudicator and built in as a first-class column rather than a footnote.

**The axes aren't quite dead, and the direction is the interesting part.** α rises **monotonically** with `beta0_ridge` (16.1 → 16.5 → 17.5 at fixed `l2reg`) and Σβ² dips ~4% at `l2reg=1e-6`. Both penalties genuinely touch the optimum — they're just 1–2 orders of magnitude too weak to move it. That's a *calibration* statement, not a structural one.

### The honest limit (please read this bit)

> Convergence was **0/8 before the scan began**. This grid could therefore never have detected a convergence *gain* — only the absence of a rescue. Per the `maxiter-scan` finding, the inner cap is the dominant convergence lever (0/16 → 3/16 → 12/16 over inner maxiter 1/10/100), and this grid inherits the middle `maxiter=10`.
>
> So the defensible claim is **"regularization cannot rescue convergence at an inadequate inner cap"** — *not* "these regularizers are inert." #285 separates the two.

**Standing findings:** the L2-knee finding is **sharpened** (its other end is now pinned: below the knee, L2 is inert against an active clip — the clip is what's binding on β). The first `beta0_ridge` finding in this lab is added. **Nothing is overturned.**

## What's here

| File | What |
|---|---|
| `grids/beta0-ridge-l2-scan.yaml` | The grid. `softplus-floor-off.yaml`'s fixed block verbatim, minus the two axes moving `fixed:` → `sweep:`. |
| `diagnostics/beta0_ridge_l2_report.py` | Convergence rate, basin (Σβ², α), and replicate-shift r per `(beta0_ridge, l2reg)`. Imports `l2_fusion_report.basin_row` unchanged. |
| `diagnostics/test_beta0_ridge_l2_grid.py` | Pins the 72-cell count and asserts the inherited fixed block hasn't drifted from the baseline (mechanizes AC1). |
| `diagnostics/test_beta0_ridge_l2_report.py` | Extraction, grouping, degenerate-rate, and pivot tests. |
| `README.md` | Run log entry. |

## Notes for the reviewer

**`beta0_ridge` is not an intercept ridge.** It penalizes each non-reference condition's β0 *difference from the reference*, `(β0_d − β0_ref)²` (`jaxmodels.py:533-540`) — an L2 shift-shrinkage, structurally parallel to `fusionreg`'s L1 on the β shift. That's why the two are crossed and why the run log reads `beta0_ridge` *within* each `fusionreg` level rather than marginalized over it. The first draft of the spec had this wrong; the fresh-context review caught it.

**The bare correlation call would have been silently wrong.** `mut_param_dataset_correlation(x="fusionreg")` groups by `(dataset_name, fusionreg)` only and mean-collapses the rest (`model_collection.py:1443/787`). On a 72-fit frame that averages the 9 `(beta0_ridge, l2reg)` fits *per group* — averaging away the two axes under test. The report slices with `query=` per cell instead, extending `l2_fusion_report`'s single-axis loop to the nested pair.

**The baseline's convergence number did not exist.** #284's AC4 requires it be computed, not quoted: the `277-softplus-floor-off` run log says "pkl carries no converged/final_obj_err column" and the 0/16 it cites is #273's *different* grid. Computed here: **0/8 converged, median final_obj_err 2.29e-4**.

**`pixi run lint` does not check this code.** `pyproject.toml`'s ruff `extend-exclude` contains `experiments` (and `.*`), so `ruff check .` skips every file in this PR — and skips the whole worktree path besides. Style was verified with `black --check` (which has no such exclude) and by running ruff explicitly on each file. Both pass. Flagging because the repo's documented lint gate is vacuous here.

## Deviations from spec

Four, all additive; none changes the experiment or its conclusion.

1. **The report grew a `--results-dir` flag** (not in the spec). `harness.RESULTS_DIR` resolves next to `harness.py`, so the worktree's copy of the script could never find `results/` — which is gitignored and materializes only in the canonical clone. Without this the spec's own AC4/AC5 steps could not be run from the worktree at all. Found by running the report end-to-end against the real baseline pickle rather than trusting its tests.

2. **Added `shift_corr_pivot`** (not in the spec). `mut_param_dataset_correlation` returns a row per mut_param type (`beta_*`, `shift_*`, `predicted_func_score_*`); #284's criterion is the `shift_*` rows. The pivot isolates them so the run-log table is a direct copy rather than a hand-extraction from 32 rows. (There is no `shift_Omicron_BA1` — it's the reference condition and carries no shift parameters.)

3. **Two tests beyond the spec's list:** a `build_params` axis-survival test (proving `explode_grid`'s 72 cells actually reach `fit_models` as 72 — the distinct-value collapse is what the fitter really sees), and a synthetic `basin_table` sort test (the pickle-backed one skips on a fresh checkout, so the beta0_ridge-outermost contract was unverified exactly where it would regress). Also made AC1 executable — `test_grid_matches_the_baseline_fixed_block` asserts the whole inherited block equals the baseline's, instead of relying on a human reading a `diff`.

4. **`n_processes=16`, at the top of the spec's 12–24 band.** No deadlock: 39,950s CPU-time in 3,320s wall (12×), 0 failed. The m100 grid's 16-worker deadlock does not reproduce at this grid's light inner `maxiter=10` block, which is what the `maxiter-scan` history predicted.

**Estimates I got wrong** (both in the safe direction, noted for the next run): the pickle is **3.8 GB, not ~6.3** — sub-knee regularizers made fits cheaper than the baseline's — and the run took **55 min, not 1–2h**. Resident memory during analysis peaked ~4.6 GB, well under the ~15 GB the 213 MB/fit measurement projected, because `_report` loads and drops one cache at a time.

## Verification

**The run.** `orca04` (64-core, 1.5 TB RAM, scouted idle at 0.3% CPU), `n_processes=16`, detached tmux. `[harness] wall 3320.1s — 72 fit, 0 failed`. 39,950s of CPU-time in 3,320s wall — a 12× speedup, so the pool worked and no spawn deadlock occurred (the m100 grid's 16-worker deadlock does not reproduce at this grid's light inner `maxiter=10` block, as expected). Remote cleaned up: tmux session gone, no stray processes, load back to 2.15 from 31.

**The pickle** (`results/beta0-ridge-l2-scan/`, gitignored, 3.8 GB — not committed):
- 72 rows, 9 `(beta0_ridge, l2reg)` cells × 8 fits each — exactly the pre-registered n=8 denominator.
- Axes verified at their specified values; 0 nulls on all three.
- The inherited block verified **on every row**: `beta_clip_range=[-10,10]`, `share_alpha=True`, `recompute_scale=False`, `output_floor` null.

**Tests:** 15 passed, 1 skipped (the skip is `test_beta_control_report.py`'s, pre-existing, needs a different cache).
```
pixi run env BETA0_RIDGE_TEST_PKL=<canonical>/experiments/convergence-lab/results/277-softplus-floor-off/fit_collection.pkl \
  python -m pytest experiments/convergence-lab/diagnostics/ -q
```
**Style:** `black --check` clean on all 8 files; `ruff check` clean on each new file by explicit path. (See the lint note above — `pixi run lint` does not reach this code.)

**`basin_row`'s contract is intact:** `test_l2_fusion_report.py` still passes and `git diff --exit-code l2_fusion_report.py` is empty.

## Follow-up filed

#285 (stub, `blocked_by` this issue): re-run these axes at inner `maxiter=100`. #284 measures a regularizer axis in a regime where convergence is pinned near 0 by the inner cap — the `maxiter-scan` finding shows 0/16 → 3/16 → 12/16 over inner maxiter 1/10/100. If these axes read flat, that separates *"regularization can't rescue convergence at an inadequate inner cap"* from *"these regularizers are inert."* Captured rather than folded in; the stub carries the cost (2h31m/16 fits at m100), the 16-worker deadlock warning, and the missing m100 baseline.

Yolo trail: spec gate ✓, plan gate ✓, code review ✓ — full log in `_ignore/yolo/284.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
