### PR TITLE
Split pipeline configs into fit and downstream tiers; promote regularized prod parameter set

### DIFF
--- a/experiments/scv2-spike/README.md
+++ b/experiments/scv2-spike/README.md
@@ -53,8 +53,41 @@ snakemake -s experiments/scv2-spike/Snakefile --config profile=test -j4
 
 | File | Description |
 |------|-------------|
-| `config.yaml` | Production profile — manuscript defaults from `profile_beta0_zero_l2reg_10x` |
+| `config.yaml` | Production profile — fit tier |
+| `config_downstream.yaml` | Production profile — downstream tier |
 | `config_test.yaml` | Test profile — 10% subsample, 2 fusionreg values, 20 iterations |
+| `config_test_downstream.yaml` | Test profile — downstream tier |
+
+Every config variant has a matching `<name>_downstream.yaml` sibling. See
+**Configuration tiers** below for which keys live where and why it matters.
+
+## Configuration tiers
+
+The config is split by dependency tier so that a downstream-only edit cannot
+invalidate the expensive model fit:
+
+| File | Holds | Do edits invalidate the fit? |
+|------|-------|------------------------------|
+| `config.yaml` | `seed`, `train_frac`, data sourcing and filtering, the `fitting:` block, `reference`, `output_dir`, `skip_cross_validation`, experiment/condition membership | **Yes** |
+| `config_downstream.yaml` | `lasso_choice`, `condition_colors`, `condition_titles`, `domain_dict` | **No** |
+
+Snakemake reruns a job when an `input:` file's mtime changes, not when its
+content changes. Before the split, every rule declared the single config as an
+input, so editing `lasso_choice` — a key the fit never reads — forced a
+multi-hour refit that recomputed a byte-identical `fit_collection.pkl`. Even
+`touch config.yaml` was enough.
+
+Now only `rule evaluate` declares `config_downstream.yaml` as an `input:`.
+`prepare_data` and `cross_validation` read it too (for plot labels), but
+receive its **path via `params:`** — Snakemake does not rerun on `params:`
+changes, so a color edit cannot reach the fit.
+
+> Do not "tidy" this by adding `downstream_config` to the `input:` block of
+> `prepare_data`, `cross_validation`, or `fit_models`. That would silently
+> restore the defect. See issue #287.
+
+Retuning the chosen lasso weight, changing a plot color, or adding a
+downstream analysis therefore reuses the cached `fit_collection.pkl`.
 
 ### Source notebooks (in `notebooks/`)
 

--- a/experiments/scv2-spike/README.md
+++ b/experiments/scv2-spike/README.md
@@ -71,11 +71,12 @@ invalidate the expensive model fit:
 | `config.yaml` | `seed`, `train_frac`, data sourcing and filtering, the `fitting:` block, `reference`, `output_dir`, `skip_cross_validation`, experiment/condition membership | **Yes** |
 | `config_downstream.yaml` | `lasso_choice`, `condition_colors`, `condition_titles`, `domain_dict` | **No** |
 
-Snakemake reruns a job when an `input:` file's mtime changes, not when its
-content changes. Before the split, every rule declared the single config as an
-input, so editing `lasso_choice` — a key the fit never reads — forced a
-multi-hour refit that recomputed a byte-identical `fit_collection.pkl`. Even
-`touch config.yaml` was enough.
+Snakemake reruns a job when an `input:` file changes, but not when a `params:`
+value changes. (Snakemake 9.21 detects that change by hashing file content, not
+by comparing mtimes — so a bare `touch` does not trigger a rerun.) Before the
+split, every rule declared the single config as an input, so editing
+`lasso_choice` — a key the fit never reads — forced a multi-hour refit that
+recomputed a byte-identical `fit_collection.pkl`.
 
 Now only `rule evaluate` declares `config_downstream.yaml` as an `input:`.
 `prepare_data` and `cross_validation` read it too (for plot labels), but

--- a/experiments/scv2-spike/README.md
+++ b/experiments/scv2-spike/README.md
@@ -114,3 +114,56 @@ downstream analysis therefore reuses the cached `fit_collection.pkl`.
   the Delta pathology at high `fusionreg` in the independent-fit results.
   The output `fit_collection.pkl` has the same schema, so downstream rules
   are unchanged.
+
+> **The Delta pathology is substantially an under-convergence artifact.**
+> It was characterized when prod ran `maxiter: 50`. Raising the outer
+> `maxiter` to 200 (and lowering the inner `ge_kwargs`/`cal_kwargs` maxiter
+> to 10) removes most of it under the *independent* fitter — no continuation
+> needed. Shift replicate correlation for `shift_Delta` at
+> `fusionreg=6.4e-4` goes 0.0778 (baseline) → 0.4047, and the two drops seen
+> at `maxiter=50` (−0.111 at 1.6e-4, −0.089 at 3.2e-4 for BA2) both turn
+> positive. At a strong lasso the optimizer simply had not converged.
+>
+> This does not retire `"continuation"` — that strategy was never re-tested
+> at `maxiter: 200`, so its marginal value now is unmeasured. Treat the
+> paragraph above as motivation recorded at `maxiter: 50`, not as a
+> standing result. See issue #287.
+
+## Run log
+
+### 2026-07-28 — prod, issue #287 (`beta0_ridge`/`l2reg` promotion + maxiter split)
+
+| | |
+|---|---|
+| Host | orca05 (64 cores, 1.5 TB RAM) |
+| Branch / commit | `287-config-tier-split` @ `9c4b515` |
+| Output dir | `results-prod-287-config-tier-split` |
+| Wall-clock | **3643 s (61 min)** |
+| `fit_collection.pkl` | 1,584,437,445 bytes (1.58 GB), 18 fitted rows |
+| Workers | `n_processes: 6`, ~7 GB RSS each at steady state |
+
+**Parameter set** (verified on the fitted rows, not just the YAML):
+`beta0_ridge=0.01`, `l2reg=1e-6`, `maxiter=200` (outer) / `10` (inner
+`ge_kwargs`, `cal_kwargs`), fusionreg = the 9-value manuscript ladder.
+
+> These are **convergence-lab-derived** values, not the manuscript's ridge
+> weights (manuscript: β ridge 1e-7, α ridge 1e-3). Note also that
+> `beta0_ridge` is *shift shrinkage* — it penalizes `(β0_d − β0_ref)²`,
+> the intercept **differences**, not the intercept magnitudes.
+
+**Shift replicate correlation vs the pre-change baseline** (delta = new − baseline):
+
+| fusionreg | Δ `shift_Delta` | Δ `shift_Omicron_BA2` |
+|---|---|---|
+| 0.0 | −0.0149 | +0.0025 |
+| 5e-6 | −0.0087 | +0.0123 |
+| 1e-5 | −0.0107 | +0.0155 |
+| 2e-5 | −0.0013 | +0.0091 |
+| **4e-5** (chosen λ) | **+0.0083** | **+0.0105** |
+| 8e-5 | +0.0093 | +0.0111 |
+| 1.6e-4 | +0.0108 | +0.0054 |
+| 3.2e-4 | +0.0142 | +0.0213 |
+| 6.4e-4 | **+0.3269** | +0.0248 |
+
+At the three weakest `fusionreg` values `shift_Delta` is slightly below
+baseline (−0.015 to −0.009); at the chosen λ=4e-5 both parameters improve.

--- a/experiments/scv2-spike/Snakefile
+++ b/experiments/scv2-spike/Snakefile
@@ -36,6 +36,12 @@ else:
     _name = config.get("configname", "config")
     CONFIG_PATH = os.path.join(SPIKE_DIR, "config", f"{_name}.yaml")
 
+# Downstream tier: derived from whatever path the profile/configname logic
+# resolved, so the `configname` override keeps working with no new machinery.
+# Declared as an input ONLY on the evaluate rule, so editing it cannot
+# invalidate the cached fit. See issue #287.
+DOWNSTREAM_CONFIG_PATH = CONFIG_PATH.replace(".yaml", "_downstream.yaml")
+
 # Read output_dir from the YAML config so test profiles can isolate results
 with open(CONFIG_PATH) as _f:
     _cfg = yaml.safe_load(_f)
@@ -61,6 +67,7 @@ FIT_NOTEBOOK = os.path.join(
 # Relative config path for papermill parameter injection — avoids
 # leaking absolute server paths into executed notebook metadata.
 CONFIG_PATH_REL = os.path.relpath(CONFIG_PATH, SPIKE_DIR)
+DOWNSTREAM_CONFIG_PATH_REL = os.path.relpath(DOWNSTREAM_CONFIG_PATH, SPIKE_DIR)
 
 # Build target list — cross-validation is optional
 _all_targets = [
@@ -79,6 +86,12 @@ rule all:
         _all_targets,
 
 
+# NOTE: prepare_data and cross_validation read the downstream config for
+# labeling only (condition_colors / condition_titles), and receive its path
+# via params: — deliberately NOT via input:. Snakemake reruns on input: mtime
+# but not on params: changes, so this is what keeps a plot-color edit from
+# invalidating fit_collection.pkl. Do not "fix" this by adding
+# downstream_config to input:. See issue #287.
 rule prepare_data:
     input:
         config=CONFIG_PATH,
@@ -89,12 +102,14 @@ rule prepare_data:
         executed_notebook=os.path.join(RESULTS, "prepare_data.ipynb"),
     params:
         config_path=CONFIG_PATH_REL,
+        downstream_config_path=DOWNSTREAM_CONFIG_PATH_REL,
         output_dir=output_dir,
         cwd=SPIKE_DIR,
     shell:
         """
         papermill "{input.notebook}" "{output.executed_notebook}" \
             -p config_path "{params.config_path}" \
+            -p downstream_config_path "{params.downstream_config_path}" \
             -p output_dir "{params.output_dir}" \
             --cwd "{params.cwd}" \
         && jupyter trust "{output.executed_notebook}"
@@ -135,12 +150,14 @@ rule cross_validation:
         executed_notebook=os.path.join(RESULTS, "cross_validation.ipynb"),
     params:
         config_path=CONFIG_PATH_REL,
+        downstream_config_path=DOWNSTREAM_CONFIG_PATH_REL,
         output_dir=output_dir,
         cwd=SPIKE_DIR,
     shell:
         """
         papermill "{input.notebook}" "{output.executed_notebook}" \
             -p config_path "{params.config_path}" \
+            -p downstream_config_path "{params.downstream_config_path}" \
             -p output_dir "{params.output_dir}" \
             --cwd "{params.cwd}" \
         && jupyter trust "{output.executed_notebook}"
@@ -150,6 +167,7 @@ rule cross_validation:
 rule evaluate:
     input:
         config=CONFIG_PATH,
+        downstream_config=DOWNSTREAM_CONFIG_PATH,
         fit_collection=os.path.join(RESULTS, "fit_collection.pkl"),
         func_scores=os.path.join(RESULTS, "training_functional_scores.csv"),
         notebook=os.path.join(NOTEBOOKS, "evaluate.ipynb"),
@@ -164,12 +182,14 @@ rule evaluate:
         executed_notebook=os.path.join(RESULTS, "evaluate.ipynb"),
     params:
         config_path=CONFIG_PATH_REL,
+        downstream_config_path=DOWNSTREAM_CONFIG_PATH_REL,
         output_dir=output_dir,
         cwd=SPIKE_DIR,
     shell:
         """
         papermill "{input.notebook}" "{output.executed_notebook}" \
             -p config_path "{params.config_path}" \
+            -p downstream_config_path "{params.downstream_config_path}" \
             -p output_dir "{params.output_dir}" \
             --cwd "{params.cwd}" \
         && jupyter trust "{output.executed_notebook}"

--- a/experiments/scv2-spike/config/config.yaml
+++ b/experiments/scv2-spike/config/config.yaml
@@ -26,7 +26,7 @@ spike:
 
   # Fitting parameters — rescaled for .mean() loss normalization (V0.4.0 anchors)
   fitting:
-    maxiter: 50
+    maxiter: 200
     tol: 1.0e-4
     recompute_scale: true
     fusionreg_values: [0.0, 5.0e-6, 1.0e-5, 2.0e-5, 4.0e-5, 8.0e-5, 1.6e-4, 3.2e-4, 6.4e-4]
@@ -40,6 +40,6 @@ spike:
     share_alpha: true
     beta_clip_range: [-10, 10]
     loss_kwargs: {"δ": 1.0}
-    ge_kwargs: {tol: 1.0e-4, maxiter: 50, maxls: 40, jit: true, verbose: false}
-    cal_kwargs: {tol: 1.0e-4, maxiter: 50, maxls: 40, jit: true, verbose: false}
+    ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 40, jit: true, verbose: false}
+    cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 40, jit: true, verbose: false}
     n_processes: null  # null = auto: min(cpu_count // 2, n_models)

--- a/experiments/scv2-spike/config/config.yaml
+++ b/experiments/scv2-spike/config/config.yaml
@@ -30,8 +30,8 @@ spike:
     tol: 1.0e-4
     recompute_scale: true
     fusionreg_values: [0.0, 5.0e-6, 1.0e-5, 2.0e-5, 4.0e-5, 8.0e-5, 1.6e-4, 3.2e-4, 6.4e-4]
-    l2reg: 0.0
-    beta0_ridge: 0.0
+    l2reg: 1.0e-6
+    beta0_ridge: 0.01
     scale_fusion_by_n: false
     ge_type: "Sigmoid"
     warmstart: false

--- a/experiments/scv2-spike/config/config.yaml
+++ b/experiments/scv2-spike/config/config.yaml
@@ -24,16 +24,6 @@ spike:
   do_truncate_nonsense: true
   subsample_frac: null  # null = use all data
 
-  # Display
-  condition_colors:
-    Delta: "#F97306"
-    Omicron_BA1: "#BFBFBF"
-    Omicron_BA2: "#9400D3"
-  condition_titles:
-    Delta: "Delta"
-    Omicron_BA1: "BA.1"
-    Omicron_BA2: "BA.2"
-
   # Fitting parameters — rescaled for .mean() loss normalization (V0.4.0 anchors)
   fitting:
     maxiter: 50
@@ -53,17 +43,3 @@ spike:
     ge_kwargs: {tol: 1.0e-4, maxiter: 50, maxls: 40, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 50, maxls: 40, jit: true, verbose: false}
     n_processes: null  # null = auto: min(cpu_count // 2, n_models)
-  lasso_choice: 4.0e-5
-
-  # Spike protein domain boundaries (for downstream Phase 4 notebooks)
-  domain_dict:
-    NTD: [13, 293]
-    RBD: [330, 528]
-    SD1: [528, 590]
-    SD2: [590, 685]
-    FP: [815, 834]
-    HR1: [907, 985]
-    CH: [985, 1035]
-    CD: [1075, 1162]
-    HR2: [1162, 1211]
-    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config.yaml
+++ b/experiments/scv2-spike/config/config.yaml
@@ -42,4 +42,5 @@ spike:
     loss_kwargs: {"δ": 1.0}
     ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 40, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 40, jit: true, verbose: false}
-    n_processes: null  # null = auto: min(cpu_count // 2, n_models)
+    n_processes: 6  # pinned: auto (null) picks workers by core count alone,
+    # ignoring memory, which exhausted a 36 GB host mid-run. Never restore null.

--- a/experiments/scv2-spike/config/config_downstream.yaml
+++ b/experiments/scv2-spike/config/config_downstream.yaml
@@ -1,0 +1,28 @@
+# Downstream-tier configuration for the SARS-CoV-2 spike pipeline.
+#
+# Keys here are read ONLY by evaluate (and future plotting/analysis rules).
+# Editing this file must NOT invalidate the cached fit_collection.pkl -- that
+# is the whole point of the split. Fit-tier edits (the sibling config) DO
+# invalidate the fit.
+
+spike:
+  lasso_choice: 4.0e-05
+  condition_colors:
+    Delta: '#F97306'
+    Omicron_BA1: '#BFBFBF'
+    Omicron_BA2: '#9400D3'
+  condition_titles:
+    Delta: Delta
+    Omicron_BA1: BA.1
+    Omicron_BA2: BA.2
+  domain_dict:
+    NTD: [13, 293]
+    RBD: [330, 528]
+    SD1: [528, 590]
+    SD2: [590, 685]
+    FP: [815, 834]
+    HR1: [907, 985]
+    CH: [985, 1035]
+    CD: [1075, 1162]
+    HR2: [1162, 1211]
+    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_experimental.yaml
+++ b/experiments/scv2-spike/config/config_experimental.yaml
@@ -23,16 +23,6 @@ spike:
   do_truncate_nonsense: true
   subsample_frac: null  # null = use all data
 
-  # Display
-  condition_colors:
-    Delta: "#F97306"
-    Omicron_BA1: "#BFBFBF"
-    Omicron_BA2: "#9400D3"
-  condition_titles:
-    Delta: "Delta"
-    Omicron_BA1: "BA.1"
-    Omicron_BA2: "BA.2"
-
   # Fitting parameters — reduced for fast iteration
   fitting:
     # Strategy: "independent" fits each fusionreg from scratch (parallel);
@@ -55,20 +45,5 @@ spike:
     ge_kwargs: {tol: 1.0e-4, maxiter: 20, maxls: 40, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 20, maxls: 40, jit: true, verbose: false}
     n_processes: null  # null = auto: min(cpu_count // 2, n_models)
-  lasso_choice: 4.0e-5
-
   # Optional pipeline steps
   skip_cross_validation: true
-
-  # Spike protein domain boundaries (for downstream Phase 4 notebooks)
-  domain_dict:
-    NTD: [13, 293]
-    RBD: [330, 528]
-    SD1: [528, 590]
-    SD2: [590, 685]
-    FP: [815, 834]
-    HR1: [907, 985]
-    CH: [985, 1035]
-    CD: [1075, 1162]
-    HR2: [1162, 1211]
-    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_experimental_downstream.yaml
+++ b/experiments/scv2-spike/config/config_experimental_downstream.yaml
@@ -1,0 +1,28 @@
+# Downstream-tier configuration for the SARS-CoV-2 spike pipeline.
+#
+# Keys here are read ONLY by evaluate (and future plotting/analysis rules).
+# Editing this file must NOT invalidate the cached fit_collection.pkl -- that
+# is the whole point of the split. Fit-tier edits (the sibling config) DO
+# invalidate the fit.
+
+spike:
+  lasso_choice: 4.0e-05
+  condition_colors:
+    Delta: '#F97306'
+    Omicron_BA1: '#BFBFBF'
+    Omicron_BA2: '#9400D3'
+  condition_titles:
+    Delta: Delta
+    Omicron_BA1: BA.1
+    Omicron_BA2: BA.2
+  domain_dict:
+    NTD: [13, 293]
+    RBD: [330, 528]
+    SD1: [528, 590]
+    SD2: [590, 685]
+    FP: [815, 834]
+    HR1: [907, 985]
+    CH: [985, 1035]
+    CD: [1075, 1162]
+    HR2: [1162, 1211]
+    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_recompute_false.yaml
+++ b/experiments/scv2-spike/config/config_recompute_false.yaml
@@ -27,16 +27,6 @@ spike:
   do_truncate_nonsense: true
   subsample_frac: null  # null = use all data
 
-  # Display
-  condition_colors:
-    Delta: "#F97306"
-    Omicron_BA1: "#BFBFBF"
-    Omicron_BA2: "#9400D3"
-  condition_titles:
-    Delta: "Delta"
-    Omicron_BA1: "BA.1"
-    Omicron_BA2: "BA.2"
-
   # Fitting parameters — recompute_scale=False variant
   fitting:
     maxiter: 50
@@ -56,17 +46,3 @@ spike:
     ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
     n_processes: null  # null = auto: min(cpu_count // 2, n_models)
-  lasso_choice: 4.0e-5
-
-  # Spike protein domain boundaries (for downstream Phase 4 notebooks)
-  domain_dict:
-    NTD: [13, 293]
-    RBD: [330, 528]
-    SD1: [528, 590]
-    SD2: [590, 685]
-    FP: [815, 834]
-    HR1: [907, 985]
-    CH: [985, 1035]
-    CD: [1075, 1162]
-    HR2: [1162, 1211]
-    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_recompute_false_downstream.yaml
+++ b/experiments/scv2-spike/config/config_recompute_false_downstream.yaml
@@ -1,0 +1,28 @@
+# Downstream-tier configuration for the SARS-CoV-2 spike pipeline.
+#
+# Keys here are read ONLY by evaluate (and future plotting/analysis rules).
+# Editing this file must NOT invalidate the cached fit_collection.pkl -- that
+# is the whole point of the split. Fit-tier edits (the sibling config) DO
+# invalidate the fit.
+
+spike:
+  lasso_choice: 4.0e-05
+  condition_colors:
+    Delta: '#F97306'
+    Omicron_BA1: '#BFBFBF'
+    Omicron_BA2: '#9400D3'
+  condition_titles:
+    Delta: Delta
+    Omicron_BA1: BA.1
+    Omicron_BA2: BA.2
+  domain_dict:
+    NTD: [13, 293]
+    RBD: [330, 528]
+    SD1: [528, 590]
+    SD2: [590, 685]
+    FP: [815, 834]
+    HR1: [907, 985]
+    CH: [985, 1035]
+    CD: [1075, 1162]
+    HR2: [1162, 1211]
+    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_recompute_false_maxiter200.yaml
+++ b/experiments/scv2-spike/config/config_recompute_false_maxiter200.yaml
@@ -33,16 +33,6 @@ spike:
   do_truncate_nonsense: true
   subsample_frac: null  # null = use all data
 
-  # Display
-  condition_colors:
-    Delta: "#F97306"
-    Omicron_BA1: "#BFBFBF"
-    Omicron_BA2: "#9400D3"
-  condition_titles:
-    Delta: "Delta"
-    Omicron_BA1: "BA.1"
-    Omicron_BA2: "BA.2"
-
   # Fitting parameters — recompute_scale=False, OUTER maxiter raised to 200
   fitting:
     maxiter: 200
@@ -62,17 +52,3 @@ spike:
     ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
     n_processes: null  # null = auto: min(cpu_count // 2, n_models)
-  lasso_choice: 4.0e-5
-
-  # Spike protein domain boundaries (for downstream Phase 4 notebooks)
-  domain_dict:
-    NTD: [13, 293]
-    RBD: [330, 528]
-    SD1: [528, 590]
-    SD2: [590, 685]
-    FP: [815, 834]
-    HR1: [907, 985]
-    CH: [985, 1035]
-    CD: [1075, 1162]
-    HR2: [1162, 1211]
-    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_recompute_false_maxiter200_downstream.yaml
+++ b/experiments/scv2-spike/config/config_recompute_false_maxiter200_downstream.yaml
@@ -1,0 +1,28 @@
+# Downstream-tier configuration for the SARS-CoV-2 spike pipeline.
+#
+# Keys here are read ONLY by evaluate (and future plotting/analysis rules).
+# Editing this file must NOT invalidate the cached fit_collection.pkl -- that
+# is the whole point of the split. Fit-tier edits (the sibling config) DO
+# invalidate the fit.
+
+spike:
+  lasso_choice: 4.0e-05
+  condition_colors:
+    Delta: '#F97306'
+    Omicron_BA1: '#BFBFBF'
+    Omicron_BA2: '#9400D3'
+  condition_titles:
+    Delta: Delta
+    Omicron_BA1: BA.1
+    Omicron_BA2: BA.2
+  domain_dict:
+    NTD: [13, 293]
+    RBD: [330, 528]
+    SD1: [528, 590]
+    SD2: [590, 685]
+    FP: [815, 834]
+    HR1: [907, 985]
+    CH: [985, 1035]
+    CD: [1075, 1162]
+    HR2: [1162, 1211]
+    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_recompute_false_test.yaml
+++ b/experiments/scv2-spike/config/config_recompute_false_test.yaml
@@ -24,16 +24,6 @@ spike:
   do_truncate_nonsense: true
   subsample_frac: 0.1  # 10% subsample for fast smoke
 
-  # Display
-  condition_colors:
-    Delta: "#F97306"
-    Omicron_BA1: "#BFBFBF"
-    Omicron_BA2: "#9400D3"
-  condition_titles:
-    Delta: "Delta"
-    Omicron_BA1: "BA.1"
-    Omicron_BA2: "BA.2"
-
   # Fitting parameters — same deltas as config_recompute_false.yaml, independent
   fitting:
     maxiter: 50
@@ -53,20 +43,5 @@ spike:
     ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 10, jit: true, verbose: false}
     n_processes: null
-  lasso_choice: 4.0e-5
-
   # Keep the smoke to the fit path only
   skip_cross_validation: true
-
-  # Spike protein domain boundaries (for downstream Phase 4 notebooks)
-  domain_dict:
-    NTD: [13, 293]
-    RBD: [330, 528]
-    SD1: [528, 590]
-    SD2: [590, 685]
-    FP: [815, 834]
-    HR1: [907, 985]
-    CH: [985, 1035]
-    CD: [1075, 1162]
-    HR2: [1162, 1211]
-    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_recompute_false_test_downstream.yaml
+++ b/experiments/scv2-spike/config/config_recompute_false_test_downstream.yaml
@@ -1,0 +1,28 @@
+# Downstream-tier configuration for the SARS-CoV-2 spike pipeline.
+#
+# Keys here are read ONLY by evaluate (and future plotting/analysis rules).
+# Editing this file must NOT invalidate the cached fit_collection.pkl -- that
+# is the whole point of the split. Fit-tier edits (the sibling config) DO
+# invalidate the fit.
+
+spike:
+  lasso_choice: 4.0e-05
+  condition_colors:
+    Delta: '#F97306'
+    Omicron_BA1: '#BFBFBF'
+    Omicron_BA2: '#9400D3'
+  condition_titles:
+    Delta: Delta
+    Omicron_BA1: BA.1
+    Omicron_BA2: BA.2
+  domain_dict:
+    NTD: [13, 293]
+    RBD: [330, 528]
+    SD1: [528, 590]
+    SD2: [590, 685]
+    FP: [815, 834]
+    HR1: [907, 985]
+    CH: [985, 1035]
+    CD: [1075, 1162]
+    HR2: [1162, 1211]
+    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_test.yaml
+++ b/experiments/scv2-spike/config/config_test.yaml
@@ -23,16 +23,6 @@ spike:
   do_truncate_nonsense: true
   subsample_frac: 0.1  # 10% subsample for fast testing
 
-  # Display
-  condition_colors:
-    Delta: "#F97306"
-    Omicron_BA1: "#BFBFBF"
-    Omicron_BA2: "#9400D3"
-  condition_titles:
-    Delta: "Delta"
-    Omicron_BA1: "BA.1"
-    Omicron_BA2: "BA.2"
-
   # Fitting parameters (reduced for test)
   fitting:
     # Strategy: "independent" fits each fusionreg from scratch (parallel);
@@ -55,17 +45,3 @@ spike:
     ge_kwargs: {tol: 1.0e-4, maxiter: 2, maxls: 40, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 2, maxls: 40, jit: true, verbose: false}
     n_processes: null  # null = auto: min(cpu_count // 2, n_models)
-  lasso_choice: 4.0e-5
-
-  # Spike protein domain boundaries (for downstream Phase 4 notebooks)
-  domain_dict:
-    NTD: [13, 293]
-    RBD: [330, 528]
-    SD1: [528, 590]
-    SD2: [590, 685]
-    FP: [815, 834]
-    HR1: [907, 985]
-    CH: [985, 1035]
-    CD: [1075, 1162]
-    HR2: [1162, 1211]
-    TM: [1211, 1234]

--- a/experiments/scv2-spike/config/config_test_downstream.yaml
+++ b/experiments/scv2-spike/config/config_test_downstream.yaml
@@ -1,0 +1,28 @@
+# Downstream-tier configuration for the SARS-CoV-2 spike pipeline.
+#
+# Keys here are read ONLY by evaluate (and future plotting/analysis rules).
+# Editing this file must NOT invalidate the cached fit_collection.pkl -- that
+# is the whole point of the split. Fit-tier edits (the sibling config) DO
+# invalidate the fit.
+
+spike:
+  lasso_choice: 4.0e-05
+  condition_colors:
+    Delta: '#F97306'
+    Omicron_BA1: '#BFBFBF'
+    Omicron_BA2: '#9400D3'
+  condition_titles:
+    Delta: Delta
+    Omicron_BA1: BA.1
+    Omicron_BA2: BA.2
+  domain_dict:
+    NTD: [13, 293]
+    RBD: [330, 528]
+    SD1: [528, 590]
+    SD2: [590, 685]
+    FP: [815, 834]
+    HR1: [907, 985]
+    CH: [985, 1035]
+    CD: [1075, 1162]
+    HR2: [1162, 1211]
+    TM: [1211, 1234]

--- a/experiments/scv2-spike/notebooks/_common.py
+++ b/experiments/scv2-spike/notebooks/_common.py
@@ -8,21 +8,66 @@ import requests
 import yaml
 
 
-def load_config(config_path):
-    """Load a pipeline configuration YAML file.
+def load_config(config_path, downstream_config_path=None):
+    """Load a pipeline configuration YAML, optionally merging a downstream tier.
+
+    The spike config is split by dependency tier: the fit tier holds
+    everything the expensive model fit depends on, and the downstream tier
+    holds keys read only by evaluation and plotting. Splitting them keeps a
+    downstream edit from invalidating the cached fit.
 
     Parameters
     ----------
     config_path : str
-        Path to the YAML config file.
+        Path to the fit-tier YAML config file.
+    downstream_config_path : str or None
+        Path to the downstream-tier YAML. When None, only the fit tier is
+        loaded and the returned dict is exactly the file's contents.
 
     Returns
     -------
     dict
-        Configuration dictionary.
+        Configuration dictionary. When both tiers are given, they are merged
+        one level deep: top-level keys, and keys inside each shared top-level
+        mapping.
+
+    Raises
+    ------
+    ValueError
+        If any key is present in both tiers. A collision is always a bug in
+        the split, and resolving it silently would let a stale fit-tier value
+        shadow the downstream one.
     """
     with open(config_path) as f:
         config = yaml.safe_load(f)
+
+    if downstream_config_path is None:
+        return config
+
+    with open(downstream_config_path) as f:
+        downstream = yaml.safe_load(f) or {}
+
+    for key, value in downstream.items():
+        if key not in config:
+            config[key] = value
+            continue
+        if isinstance(config[key], dict) and isinstance(value, dict):
+            overlap = set(config[key]) & set(value)
+            if overlap:
+                raise ValueError(
+                    f"Key(s) {sorted(overlap)} appear in both the fit tier "
+                    f"({config_path}) and the downstream tier "
+                    f"({downstream_config_path}) under '{key}'. Each key must "
+                    "live in exactly one tier."
+                )
+            config[key].update(value)
+        else:
+            raise ValueError(
+                f"Key '{key}' appears in both the fit tier ({config_path}) "
+                f"and the downstream tier ({downstream_config_path}). Each "
+                "key must live in exactly one tier."
+            )
+
     return config
 
 

--- a/experiments/scv2-spike/notebooks/cross_validation.ipynb
+++ b/experiments/scv2-spike/notebooks/cross_validation.ipynb
@@ -53,6 +53,7 @@
    "outputs": [],
    "source": [
     "config_path = \"config/config.yaml\"\n",
+    "downstream_config_path = \"config/config_downstream.yaml\"\n",
     "output_dir = None"
    ]
   },
@@ -62,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config = load_config(config_path)\n",
+    "config = load_config(config_path, downstream_config_path)\n",
     "spike = config[\"spike\"]\n",
     "fit_config = spike[\"fitting\"]\n",
     "reference = spike[\"reference\"]\n",

--- a/experiments/scv2-spike/notebooks/evaluate.ipynb
+++ b/experiments/scv2-spike/notebooks/evaluate.ipynb
@@ -35,14 +35,29 @@
     ]
    },
    "outputs": [],
-   "source": "config_path = \"config/config.yaml\"\noutput_dir = None"
+   "source": [
+    "config_path = \"config/config.yaml\"\n",
+    "downstream_config_path = \"config/config_downstream.yaml\"\n",
+    "output_dir = None"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "config = load_config(config_path)\nspike = config[\"spike\"]\nfit_config = spike[\"fitting\"]\nlasso_choice = spike[\"lasso_choice\"]\ncondition_titles = spike[\"condition_titles\"]\ncondition_colors = spike[\"condition_colors\"]\nexperiment_conditions = spike[\"experiment_conditions\"]\n\nif output_dir is None:\n    output_dir = spike.get(\"output_dir\", \"results\")"
+   "source": [
+    "config = load_config(config_path, downstream_config_path)\n",
+    "spike = config[\"spike\"]\n",
+    "fit_config = spike[\"fitting\"]\n",
+    "lasso_choice = spike[\"lasso_choice\"]\n",
+    "condition_titles = spike[\"condition_titles\"]\n",
+    "condition_colors = spike[\"condition_colors\"]\n",
+    "experiment_conditions = spike[\"experiment_conditions\"]\n",
+    "\n",
+    "if output_dir is None:\n",
+    "    output_dir = spike.get(\"output_dir\", \"results\")"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/experiments/scv2-spike/notebooks/prepare_data.ipynb
+++ b/experiments/scv2-spike/notebooks/prepare_data.ipynb
@@ -61,6 +61,7 @@
    "outputs": [],
    "source": [
     "config_path = \"config/config.yaml\"\n",
+    "downstream_config_path = \"config/config_downstream.yaml\"\n",
     "output_dir = None"
    ]
   },
@@ -70,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config = load_config(config_path)\n",
+    "config = load_config(config_path, downstream_config_path)\n",
     "spike = config[\"spike\"]\n",
     "seed = config[\"seed\"]\n",
     "\n",

--- a/experiments/simulation/README.md
+++ b/experiments/simulation/README.md
@@ -79,7 +79,7 @@ snakemake -s experiments/simulation/Snakefile --config profile=test -j4
 
 ## Configuration
 
-- **Production**: `config/config.yaml` — manuscript defaults (genelength=50, 9 fusionreg values, maxiter=100)
+- **Production**: `config/config.yaml` — manuscript defaults (genelength=50, 9 fusionreg values, outer maxiter=200 / inner ge+cal maxiter=10)
 - **Test**: `config/config_test.yaml` — reduced parameters (genelength=10, 2 fusionreg values, maxiter=20)
 
 Each has a matching `<name>_downstream.yaml` sibling.
@@ -111,3 +111,55 @@ Now only `rule evaluate` and `rule manuscript_figures` declare
 
 Unlike spike, simulation's downstream tier holds `lasso_choice` alone — this
 pipeline has no `condition_colors`, `condition_titles`, or `domain_dict`.
+
+## Run log
+
+### 2026-07-29 — prod, issue #287 (`beta0_ridge`/`l2reg` promotion + maxiter split)
+
+| | |
+|---|---|
+| Host | orca05 (64 cores, 1.5 TB RAM) |
+| Branch / commit | `287-config-tier-split` @ `9c4b515` |
+| Output dir | `results-prod-287-config-tier-split` |
+| Wall-clock | **7519 s (125 min)** |
+| `fit_collection.pkl` | 535,372,253 bytes (535 MB), 54 fitted rows |
+| Workers | `n_processes: 6`, **~42 GB RSS each** at steady state |
+
+**Parameter set** (verified on the fitted rows, not just the YAML):
+`beta0_ridge=0.01`, `l2reg=1e-6`, `maxiter=200` (outer) / `10` (inner
+`ge_kwargs`, `cal_kwargs`), fusionreg = the 9-value manuscript ladder.
+
+> These are **convergence-lab-derived** values, not the manuscript's ridge
+> weights (manuscript: β ridge 1e-7, α ridge 1e-3). `beta0_ridge` is
+> *shift shrinkage* — it penalizes `(β0_d − β0_ref)²`, the intercept
+> **differences**, not the intercept magnitudes.
+
+#### AC7 — ground-truth shift recovery at `fusionreg = 8e-5`
+
+Pre-registered gate: no cell may drop more than 0.02 absolute, and the
+six-cell mean may not drop.
+
+| measurement_type | library | baseline | new | Δ |
+|---|---|---|---|---|
+| observed_phenotype | lib_1 | 0.8319 | 0.9657 | **+0.1338** |
+| loose_bottle | lib_1 | 0.8071 | 0.9401 | **+0.1329** |
+| tight_bottle | lib_1 | 0.7382 | 0.8197 | **+0.0815** |
+| observed_phenotype | lib_2 | 0.8174 | 0.9696 | **+0.1522** |
+| loose_bottle | lib_2 | 0.8011 | 0.9536 | **+0.1525** |
+| tight_bottle | lib_2 | 0.7390 | 0.8282 | **+0.0892** |
+
+Six-cell mean **0.7891 → 0.9128 (+0.1237)**; worst per-cell change is
+**+0.0815**. All six cells improved. **AC7: PASS.**
+
+`beta` recovery moved −0.0009 to −0.0030 (e.g. 1.0000 → 0.9970) against
+near-perfect baselines. AC7 gates on `shift`, not `beta`.
+
+#### Sizing note — why this does not run on a laptop
+
+Each simulation fit worker holds **~42 GB resident** at steady state, ~6×
+spike's footprint. `n_processes: null` selects `min(cpu_count // 2, n_models)`
+from **core count alone, with no regard for memory**: on a 36 GB laptop that
+chose 7 workers (~294 GB of demand) and kernel-panicked the host mid-run,
+losing a complete production fit. A single worker exceeds that machine's
+total RAM. Always pin `n_processes` explicitly, and size it against memory
+rather than cores.

--- a/experiments/simulation/README.md
+++ b/experiments/simulation/README.md
@@ -94,10 +94,12 @@ invalidate the expensive model fit:
 | `config.yaml` | `seed`, `train_frac`, the simulation parameters, the `fitting:` block, `output_dir` | **Yes** |
 | `config_downstream.yaml` | `lasso_choice` (only) | **No** |
 
-Snakemake reruns a job when an `input:` file's mtime changes, not when its
-content changes. Before the split, every rule declared the single config as an
-input, so editing `lasso_choice` — a key the fit never reads — forced a full
-refit that recomputed a byte-identical `fit_collection.pkl`.
+Snakemake reruns a job when an `input:` file changes, but not when a `params:`
+value changes. (Snakemake 9.21 detects that change by hashing file content, not
+by comparing mtimes — so a bare `touch` does not trigger a rerun.) Before the
+split, every rule declared the single config as an input, so editing
+`lasso_choice` — a key the fit never reads — forced a full refit that recomputed
+a byte-identical `fit_collection.pkl`.
 
 Now only `rule evaluate` and `rule manuscript_figures` declare
 `config_downstream.yaml` as an `input:`. `simulate_data`, `fit_models`, and

--- a/experiments/simulation/README.md
+++ b/experiments/simulation/README.md
@@ -79,5 +79,33 @@ snakemake -s experiments/simulation/Snakefile --config profile=test -j4
 
 ## Configuration
 
-- **Production**: `config/config.yaml` — manuscript defaults (genelength=50, 4 fusionreg values, maxiter=100)
+- **Production**: `config/config.yaml` — manuscript defaults (genelength=50, 9 fusionreg values, maxiter=100)
 - **Test**: `config/config_test.yaml` — reduced parameters (genelength=10, 2 fusionreg values, maxiter=20)
+
+Each has a matching `<name>_downstream.yaml` sibling.
+
+### Configuration tiers
+
+The config is split by dependency tier so that a downstream-only edit cannot
+invalidate the expensive model fit:
+
+| File | Holds | Do edits invalidate the fit? |
+|------|-------|------------------------------|
+| `config.yaml` | `seed`, `train_frac`, the simulation parameters, the `fitting:` block, `output_dir` | **Yes** |
+| `config_downstream.yaml` | `lasso_choice` (only) | **No** |
+
+Snakemake reruns a job when an `input:` file's mtime changes, not when its
+content changes. Before the split, every rule declared the single config as an
+input, so editing `lasso_choice` — a key the fit never reads — forced a full
+refit that recomputed a byte-identical `fit_collection.pkl`.
+
+Now only `rule evaluate` and `rule manuscript_figures` declare
+`config_downstream.yaml` as an `input:`. `simulate_data`, `fit_models`, and
+`cross_validation` do not reference it at all.
+
+> Do not "tidy" this by adding `downstream_config` to the `input:` block of
+> `simulate_data`, `fit_models`, or `cross_validation`. That would silently
+> restore the defect. See issue #287.
+
+Unlike spike, simulation's downstream tier holds `lasso_choice` alone — this
+pipeline has no `condition_colors`, `condition_titles`, or `domain_dict`.

--- a/experiments/simulation/Snakefile
+++ b/experiments/simulation/Snakefile
@@ -25,6 +25,11 @@ if profile == "test":
 else:
     CONFIG_PATH = os.path.join(SIM_DIR, "config", "config.yaml")
 
+# Downstream tier: derived from whatever path the profile logic resolved.
+# Declared as an input ONLY on downstream rules, so editing it cannot
+# invalidate the cached fit. See issue #287.
+DOWNSTREAM_CONFIG_PATH = CONFIG_PATH.replace(".yaml", "_downstream.yaml")
+
 # Read output_dir from the YAML config so test profiles can isolate results
 with open(CONFIG_PATH) as _f:
     _cfg = yaml.safe_load(_f)
@@ -37,6 +42,7 @@ FIGURES = os.path.join(RESULTS, "figures")
 # Relative config path for papermill parameter injection — avoids
 # leaking absolute server paths into executed notebook metadata.
 CONFIG_PATH_REL = os.path.relpath(CONFIG_PATH, SIM_DIR)
+DOWNSTREAM_CONFIG_PATH_REL = os.path.relpath(DOWNSTREAM_CONFIG_PATH, SIM_DIR)
 
 
 rule all:
@@ -93,6 +99,7 @@ rule fit_models:
 rule evaluate:
     input:
         config=CONFIG_PATH,
+        downstream_config=DOWNSTREAM_CONFIG_PATH,
         fit_collection=os.path.join(RESULTS, "fit_collection.pkl"),
         muteffects=os.path.join(RESULTS, "simulated_muteffects.csv"),
         func_scores=os.path.join(RESULTS, "simulated_func_scores.csv"),
@@ -112,11 +119,13 @@ rule evaluate:
         executed_notebook=os.path.join(RESULTS, "evaluate.ipynb"),
     params:
         config_path=CONFIG_PATH_REL,
+        downstream_config_path=DOWNSTREAM_CONFIG_PATH_REL,
         output_dir=output_dir,
     shell:
         """
         papermill {input.notebook} {output.executed_notebook} \
             -p config_path {params.config_path} \
+            -p downstream_config_path {params.downstream_config_path} \
             -p output_dir {params.output_dir} \
             --cwd {SIM_DIR} \
         && jupyter trust {output.executed_notebook}
@@ -147,6 +156,7 @@ rule cross_validation:
 rule manuscript_figures:
     input:
         config=CONFIG_PATH,
+        downstream_config=DOWNSTREAM_CONFIG_PATH,
         muteffects=os.path.join(RESULTS, "simulated_muteffects.csv"),
         func_scores=os.path.join(RESULTS, "simulated_func_scores.csv"),
         model_vs_truth=os.path.join(
@@ -173,11 +183,13 @@ rule manuscript_figures:
         sparsity_diag=os.path.join(FIGURES, "sparsity_diagnostic.pdf"),
     params:
         config_path=CONFIG_PATH_REL,
+        downstream_config_path=DOWNSTREAM_CONFIG_PATH_REL,
         output_dir=output_dir,
     shell:
         """
         papermill {input.notebook} {output.executed_notebook} \
             -p config_path {params.config_path} \
+            -p downstream_config_path {params.downstream_config_path} \
             -p output_dir {params.output_dir} \
             --cwd {SIM_DIR} \
         && jupyter trust {output.executed_notebook}

--- a/experiments/simulation/config/config.yaml
+++ b/experiments/simulation/config/config.yaml
@@ -43,4 +43,3 @@ simulation:
     ge_kwargs: {tol: 1.0e-4, maxiter: 100, maxls: 40, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 100, maxls: 40, jit: true, verbose: false}
     n_processes: null  # null = auto: min(cpu_count // 2, n_models)
-  lasso_choice: 8.0e-5

--- a/experiments/simulation/config/config.yaml
+++ b/experiments/simulation/config/config.yaml
@@ -31,8 +31,8 @@ simulation:
     maxiter: 100
     tol: 1.0e-4
     fusionreg_values: [0.0, 5.0e-6, 1.0e-5, 2.0e-5, 4.0e-5, 8.0e-5, 1.6e-4, 3.2e-4, 6.4e-4]
-    l2reg: 0.0
-    beta0_ridge: 0.0
+    l2reg: 1.0e-6
+    beta0_ridge: 0.01
     ge_type: "Sigmoid"
     warmstart: false
     beta0_init: {h1: 5.0, h2: 0.0}

--- a/experiments/simulation/config/config.yaml
+++ b/experiments/simulation/config/config.yaml
@@ -28,7 +28,7 @@ simulation:
     loose_bottle: 100
   output_dir: results
   fitting:
-    maxiter: 100
+    maxiter: 200
     tol: 1.0e-4
     fusionreg_values: [0.0, 5.0e-6, 1.0e-5, 2.0e-5, 4.0e-5, 8.0e-5, 1.6e-4, 3.2e-4, 6.4e-4]
     l2reg: 1.0e-6
@@ -40,7 +40,7 @@ simulation:
     share_alpha: true
     beta_clip_range: [-10, 10]
     loss_kwargs: {"δ": 1.0}
-    ge_kwargs: {tol: 1.0e-4, maxiter: 100, maxls: 40, jit: true, verbose: false}
-    cal_kwargs: {tol: 1.0e-4, maxiter: 100, maxls: 40, jit: true, verbose: false}
+    ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 40, jit: true, verbose: false}
+    cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 40, jit: true, verbose: false}
     n_processes: 2  # pinned: auto (null) picks workers by core count alone,
     # ignoring memory, which exhausted a 36 GB host mid-run. Never restore null.

--- a/experiments/simulation/config/config.yaml
+++ b/experiments/simulation/config/config.yaml
@@ -42,5 +42,5 @@ simulation:
     loss_kwargs: {"δ": 1.0}
     ge_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 40, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 10, maxls: 40, jit: true, verbose: false}
-    n_processes: 2  # pinned: auto (null) picks workers by core count alone,
+    n_processes: 6  # pinned: auto (null) picks workers by core count alone,
     # ignoring memory, which exhausted a 36 GB host mid-run. Never restore null.

--- a/experiments/simulation/config/config.yaml
+++ b/experiments/simulation/config/config.yaml
@@ -42,4 +42,5 @@ simulation:
     loss_kwargs: {"δ": 1.0}
     ge_kwargs: {tol: 1.0e-4, maxiter: 100, maxls: 40, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 100, maxls: 40, jit: true, verbose: false}
-    n_processes: null  # null = auto: min(cpu_count // 2, n_models)
+    n_processes: 2  # pinned: auto (null) picks workers by core count alone,
+    # ignoring memory, which exhausted a 36 GB host mid-run. Never restore null.

--- a/experiments/simulation/config/config_downstream.yaml
+++ b/experiments/simulation/config/config_downstream.yaml
@@ -1,0 +1,8 @@
+# Downstream-tier configuration for the simulation pipeline.
+#
+# Keys here are read ONLY by evaluate and manuscript_figures. Editing this
+# file must NOT invalidate the cached fit_collection.pkl -- that is the whole
+# point of the split. Fit-tier edits (the sibling config) DO invalidate the fit.
+
+simulation:
+  lasso_choice: 8.0e-05

--- a/experiments/simulation/config/config_test.yaml
+++ b/experiments/simulation/config/config_test.yaml
@@ -43,4 +43,3 @@ simulation:
     ge_kwargs: {tol: 1.0e-4, maxiter: 2, maxls: 40, jit: true, verbose: false}
     cal_kwargs: {tol: 1.0e-4, maxiter: 2, maxls: 40, jit: true, verbose: false}
     n_processes: null  # null = auto: min(cpu_count // 2, n_models)
-  lasso_choice: 8.0e-5

--- a/experiments/simulation/config/config_test_downstream.yaml
+++ b/experiments/simulation/config/config_test_downstream.yaml
@@ -1,0 +1,8 @@
+# Downstream-tier configuration for the simulation pipeline.
+#
+# Keys here are read ONLY by evaluate and manuscript_figures. Editing this
+# file must NOT invalidate the cached fit_collection.pkl -- that is the whole
+# point of the split. Fit-tier edits (the sibling config) DO invalidate the fit.
+
+simulation:
+  lasso_choice: 8.0e-05

--- a/experiments/simulation/notebooks/_common.py
+++ b/experiments/simulation/notebooks/_common.py
@@ -6,21 +6,66 @@ import pandas as pd
 import yaml
 
 
-def load_config(config_path):
-    """Load a pipeline configuration YAML file.
+def load_config(config_path, downstream_config_path=None):
+    """Load a pipeline configuration YAML, optionally merging a downstream tier.
+
+    The simulation config is split by dependency tier: the fit tier holds
+    everything the expensive model fit depends on, and the downstream tier
+    holds keys read only by evaluation and plotting. Splitting them keeps a
+    downstream edit from invalidating the cached fit.
 
     Parameters
     ----------
     config_path : str
-        Path to the YAML config file.
+        Path to the fit-tier YAML config file.
+    downstream_config_path : str or None
+        Path to the downstream-tier YAML. When None, only the fit tier is
+        loaded and the returned dict is exactly the file's contents.
 
     Returns
     -------
     dict
-        Configuration dictionary.
+        Configuration dictionary. When both tiers are given, they are merged
+        one level deep: top-level keys, and keys inside each shared top-level
+        mapping.
+
+    Raises
+    ------
+    ValueError
+        If any key is present in both tiers. A collision is always a bug in
+        the split, and resolving it silently would let a stale fit-tier value
+        shadow the downstream one.
     """
     with open(config_path) as f:
         config = yaml.safe_load(f)
+
+    if downstream_config_path is None:
+        return config
+
+    with open(downstream_config_path) as f:
+        downstream = yaml.safe_load(f) or {}
+
+    for key, value in downstream.items():
+        if key not in config:
+            config[key] = value
+            continue
+        if isinstance(config[key], dict) and isinstance(value, dict):
+            overlap = set(config[key]) & set(value)
+            if overlap:
+                raise ValueError(
+                    f"Key(s) {sorted(overlap)} appear in both the fit tier "
+                    f"({config_path}) and the downstream tier "
+                    f"({downstream_config_path}) under '{key}'. Each key must "
+                    "live in exactly one tier."
+                )
+            config[key].update(value)
+        else:
+            raise ValueError(
+                f"Key '{key}' appears in both the fit tier ({config_path}) "
+                f"and the downstream tier ({downstream_config_path}). Each "
+                "key must live in exactly one tier."
+            )
+
     return config
 
 

--- a/experiments/simulation/notebooks/cross_validation.ipynb
+++ b/experiments/simulation/notebooks/cross_validation.ipynb
@@ -81,10 +81,10 @@
     "train_frac = config[\"train_frac\"]\n",
     "if output_dir is None:\n",
     "    output_dir = sim[\"output_dir\"]\n",
-    "lasso_choice = sim[\"lasso_choice\"]\n",
     "\n",
     "os.makedirs(output_dir, exist_ok=True)\n",
-    "print(f\"Output directory: {output_dir}\")\n"
+    "print(f\"Output directory: {output_dir}\")\n",
+    ""
    ],
    "outputs": [],
    "execution_count": null

--- a/experiments/simulation/notebooks/evaluate.ipynb
+++ b/experiments/simulation/notebooks/evaluate.ipynb
@@ -40,6 +40,7 @@
    "outputs": [],
    "source": [
     "config_path = \"config/config.yaml\"\n",
+    "downstream_config_path = \"config/config_downstream.yaml\"\n",
     "output_dir = None"
    ]
   },
@@ -50,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config = load_config(config_path)\n",
+    "config = load_config(config_path, downstream_config_path)\n",
     "sim = config[\"simulation\"]\n",
     "fit_config = sim[\"fitting\"]\n",
     "\n",

--- a/experiments/simulation/notebooks/manuscript_figures.ipynb
+++ b/experiments/simulation/notebooks/manuscript_figures.ipynb
@@ -62,6 +62,7 @@
    },
    "source": [
     "config_path = \"config/config.yaml\"\n",
+    "downstream_config_path = \"config/config_downstream.yaml\"\n",
     "output_dir = None"
    ],
    "execution_count": null,
@@ -77,11 +78,11 @@
     "sys.path.insert(0, \"notebooks\")\n",
     "from _common import load_config\n",
     "\n",
-    "config = load_config(config_path)\n",
+    "config = load_config(config_path, downstream_config_path)\n",
     "sim = config[\"simulation\"]\n",
     "if output_dir is None:\n",
     "    output_dir = sim[\"output_dir\"]\n",
-    "lasso_choice = sim.get(\"lasso_choice\", 4.0)\n",
+    "lasso_choice = sim[\"lasso_choice\"]\n",
     "\n",
     "# GE parameters for Panel B overlay\n",
     "wt_latent = sim[\"wt_latent\"]\n",

--- a/tests/test_config_tiers.py
+++ b/tests/test_config_tiers.py
@@ -81,3 +81,83 @@ def test_missing_downstream_file_raises(load_config, section, tmp_path):
     fit = _write(tmp_path, "fit.yaml", {section: {}})
     with pytest.raises(FileNotFoundError):
         load_config(fit, str(tmp_path / "nope.yaml"))
+
+
+SIM_VARIANTS = ["config", "config_test"]
+SPIKE_VARIANTS = [
+    "config",
+    "config_test",
+    "config_experimental",
+    "config_recompute_false",
+    "config_recompute_false_test",
+    "config_recompute_false_maxiter200",
+]
+SPIKE_DOWNSTREAM_KEYS = {
+    "lasso_choice",
+    "condition_colors",
+    "condition_titles",
+    "domain_dict",
+}
+
+VARIANTS = [("simulation", SIM_DIR, n) for n in SIM_VARIANTS] + [
+    ("spike", SPIKE_DIR, n) for n in SPIKE_VARIANTS
+]
+
+
+def _section_keys(path, section):
+    with open(path) as f:
+        return set((yaml.safe_load(f) or {}).get(section, {}))
+
+
+@pytest.mark.parametrize("section,pipeline_dir,name", VARIANTS)
+def test_every_variant_has_a_downstream_sibling(section, pipeline_dir, name):
+    """Every config variant in both pipelines has a downstream sibling."""
+    config_dir = os.path.join(pipeline_dir, "config")
+    assert os.path.exists(os.path.join(config_dir, f"{name}.yaml"))
+    assert os.path.exists(os.path.join(config_dir, f"{name}_downstream.yaml"))
+
+
+@pytest.mark.parametrize("section,pipeline_dir,name", VARIANTS)
+def test_downstream_keys_left_the_fit_tier(section, pipeline_dir, name):
+    """No downstream key remains in any fit-tier config."""
+    config_dir = os.path.join(pipeline_dir, "config")
+    expected = {"lasso_choice"} if section == "simulation" else SPIKE_DOWNSTREAM_KEYS
+    fit_keys = _section_keys(os.path.join(config_dir, f"{name}.yaml"), section)
+    leftover = fit_keys & expected
+    assert not leftover, f"{name}.yaml still holds {sorted(leftover)}"
+
+
+@pytest.mark.parametrize("section,pipeline_dir,name", VARIANTS)
+def test_tiers_merge_without_collision(section, pipeline_dir, name):
+    """Every variant's two tiers merge cleanly and expose lasso_choice."""
+    load_config = (
+        SIM_COMMON.load_config if section == "simulation" else SPIKE_COMMON.load_config
+    )
+    config_dir = os.path.join(pipeline_dir, "config")
+    merged = load_config(
+        os.path.join(config_dir, f"{name}.yaml"),
+        os.path.join(config_dir, f"{name}_downstream.yaml"),
+    )
+    assert "lasso_choice" in merged[section]
+
+
+def test_simulation_downstream_tier_holds_only_lasso_choice():
+    """Simulation's downstream tier is lasso_choice alone — it has no cosmetics."""
+    config_dir = os.path.join(SIM_DIR, "config")
+    for name in SIM_VARIANTS:
+        with open(os.path.join(config_dir, f"{name}_downstream.yaml")) as f:
+            payload = yaml.safe_load(f)
+        assert set(payload) == {"simulation"}
+        assert set(payload["simulation"]) == {"lasso_choice"}
+
+
+def test_fit_tier_retains_keys_the_notebook_scan_cannot_see():
+    """Snakefile-read and helper-read keys must stay in the fit tier."""
+    config_dir = os.path.join(SPIKE_DIR, "config")
+    experimental = _section_keys(
+        os.path.join(config_dir, "config_experimental.yaml"), "spike"
+    )
+    assert "skip_cross_validation" in experimental
+    prod = _section_keys(os.path.join(config_dir, "config.yaml"), "spike")
+    assert "data_url" in prod
+    assert "output_dir" in prod

--- a/tests/test_config_tiers.py
+++ b/tests/test_config_tiers.py
@@ -1,0 +1,83 @@
+"""Tests for two-tier config loading in both experiment pipelines.
+
+The pipeline configs are split into a fit tier and a downstream tier so a
+downstream-only edit cannot invalidate the cached model fit. These tests pin
+the loader contract that split depends on.
+"""
+
+import importlib.util
+import os
+
+import pytest
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIM_DIR = os.path.join(REPO_ROOT, "experiments", "simulation")
+SPIKE_DIR = os.path.join(REPO_ROOT, "experiments", "scv2-spike")
+
+
+def _load_common(pipeline_dir, module_name):
+    """Import a pipeline's notebooks/_common.py under a unique module name."""
+    path = os.path.join(pipeline_dir, "notebooks", "_common.py")
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SIM_COMMON = _load_common(SIM_DIR, "sim_common_for_tests")
+SPIKE_COMMON = _load_common(SPIKE_DIR, "spike_common_for_tests")
+
+PIPELINES = [
+    pytest.param(SIM_COMMON.load_config, "simulation", id="simulation"),
+    pytest.param(SPIKE_COMMON.load_config, "spike", id="spike"),
+]
+
+
+def _write(tmp_path, name, payload):
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(payload))
+    return str(path)
+
+
+@pytest.mark.parametrize("load_config,section", PIPELINES)
+def test_single_tier_unchanged(load_config, section, tmp_path):
+    """Loading without a downstream path returns the file verbatim."""
+    fit = _write(tmp_path, "fit.yaml", {"seed": 4, section: {"output_dir": "results"}})
+    assert load_config(fit) == {"seed": 4, section: {"output_dir": "results"}}
+
+
+@pytest.mark.parametrize("load_config,section", PIPELINES)
+def test_merges_downstream_section(load_config, section, tmp_path):
+    """Downstream keys land in the same section as fit keys."""
+    fit = _write(tmp_path, "fit.yaml", {"seed": 4, section: {"output_dir": "results"}})
+    down = _write(tmp_path, "down.yaml", {section: {"lasso_choice": 8.0e-5}})
+    merged = load_config(fit, down)
+    assert merged[section]["output_dir"] == "results"
+    assert merged[section]["lasso_choice"] == 8.0e-5
+
+
+@pytest.mark.parametrize("load_config,section", PIPELINES)
+def test_collision_raises(load_config, section, tmp_path):
+    """A key in both tiers is an error, not a last-wins resolution."""
+    fit = _write(tmp_path, "fit.yaml", {section: {"lasso_choice": 1.0}})
+    down = _write(tmp_path, "down.yaml", {section: {"lasso_choice": 2.0}})
+    with pytest.raises(ValueError, match="lasso_choice"):
+        load_config(fit, down)
+
+
+@pytest.mark.parametrize("load_config,section", PIPELINES)
+def test_top_level_collision_raises(load_config, section, tmp_path):
+    """Collisions are detected at the top level too."""
+    fit = _write(tmp_path, "fit.yaml", {"seed": 4})
+    down = _write(tmp_path, "down.yaml", {"seed": 5})
+    with pytest.raises(ValueError, match="seed"):
+        load_config(fit, down)
+
+
+@pytest.mark.parametrize("load_config,section", PIPELINES)
+def test_missing_downstream_file_raises(load_config, section, tmp_path):
+    """A missing downstream file fails loudly rather than silently skipping."""
+    fit = _write(tmp_path, "fit.yaml", {section: {}})
+    with pytest.raises(FileNotFoundError):
+        load_config(fit, str(tmp_path / "nope.yaml"))


### PR DESCRIPTION
Closes #287

Splits every pipeline config into a **fit tier** and a **downstream tier**, so a
presentation-only edit (a lasso choice, a plot color) can no longer invalidate a
multi-hour model fit. Promotes the convergence-lab parameter set
(`beta0_ridge=0.01`, `l2reg=1e-6`) to production in both pipelines, and
decouples the outer/inner optimizer iteration counts (`maxiter` 200 outer / 10
inner).

## The mechanism

Snakemake reruns a job when an `input:` file changes, but **not** when a
`params:` value changes. That asymmetry is the entire fix:

```
                     downstream as input:   path via params:
simulation
  simulate_data              no                    no
  fit_models                 no                    no    <- severed
  cross_validation           no                    no
  evaluate                  YES                   yes
  manuscript_figures        YES                   yes
spike
  prepare_data               no                   yes    <- reads it, immune to it
  fit_models                 no                    no    <- severed
  cross_validation           no                   yes
  evaluate                  YES                   yes
```

`prepare_data`/`cross_validation` need `condition_colors`/`condition_titles` for
labels, so they receive the downstream config's **path** via `params:` — they can
read it without being invalidated by it.

## Evidence

### AC3b — the split is a pure refactor

Determinism control first (same profile twice on unmodified `main`): all 4
artifacts **DETERMINISTIC**. Then pre-split vs post-split at unchanged
parameters:

```
IDENTICAL: mutations_df.csv, fit_sparsity.csv, collection_muts.csv, cross_validation_loss.csv
```

Caveat: spike's `test` profile uses `strategy: "continuation"`, so this exercised
`fit_models_path.ipynb`, not prod's `fit_models.ipynb`.

### AC4 — cache invariance

| Edit | Rules rerun | Verdict |
|---|---|---|
| `lasso_choice` 4e-5→8e-5 (downstream) | `evaluate` only | fit reused |
| condition color `#F97306`→`#FF0000` (downstream) | `evaluate` only | fit reused |
| `tol` 1.0e-4→1.1e-4 (fit tier) — **control** | `prepare_data`, `fit_models`, `cross_validation`, `evaluate` | correctly invalidates |

### AC6 — parameter set verified on the fitted rows

Read back from `fit_collection.pkl`, not just the YAML:

| | rows | `beta0_ridge` | `l2reg` | `maxiter` | `fusionreg` |
|---|---|---|---|---|---|
| spike | 18 | `[0.01]` | `[1e-06]` | `[200]` | exact 9-value ladder |
| simulation | 54 | `[0.01]` | `[1e-06]` | `[200]` | exact 9-value ladder |

### AC7 — simulation ground-truth recovery (pre-registered science gate)

Threshold: no cell may drop >0.02 absolute at `fusionreg=8e-5`, and the six-cell
mean may not drop.

| measurement_type | library | baseline | new | Δ |
|---|---|---|---|---|
| observed_phenotype | lib_1 | 0.8319 | 0.9657 | **+0.1338** |
| loose_bottle | lib_1 | 0.8071 | 0.9401 | **+0.1329** |
| tight_bottle | lib_1 | 0.7382 | 0.8197 | **+0.0815** |
| observed_phenotype | lib_2 | 0.8174 | 0.9696 | **+0.1522** |
| loose_bottle | lib_2 | 0.8011 | 0.9536 | **+0.1525** |
| tight_bottle | lib_2 | 0.7390 | 0.8282 | **+0.0892** |

Six-cell mean **0.7891 → 0.9128 (+0.1237)**. Worst per-cell change **+0.0815**.
All six cells improved. **AC7: PASS.**

`beta` recovery moved −0.0009 to −0.0030 (e.g. 1.0000 → 0.9970) against
near-perfect baselines. AC7 gates on `shift`, not `beta`, so this does not gate —
but it is a decrease and is recorded rather than omitted.

### AC8 — spike replicate correlation

`beta0_ridge=0.01` tightened intercept spread as an L2 shift-penalty should; no
collapse. Shift replicate correlation vs baseline:

| fusionreg | Δ `shift_Delta` | Δ `shift_Omicron_BA2` |
|---|---|---|
| 0.0 | −0.0149 | +0.0025 |
| 5e-6 | −0.0087 | +0.0123 |
| 1e-5 | −0.0107 | +0.0155 |
| 2e-5 | −0.0013 | +0.0091 |
| **4e-5** (chosen λ) | **+0.0083** | **+0.0105** |
| 8e-5 | +0.0093 | +0.0111 |
| 1.6e-4 | +0.0108 | +0.0054 |
| 3.2e-4 | +0.0142 | +0.0213 |
| 6.4e-4 | **+0.3269** | +0.0248 |

At the three weakest `fusionreg` values `shift_Delta` sits slightly below
baseline (−0.015 to −0.009); at the chosen λ both parameters improve.

### The maxiter change surfaced a documentation defect

Both READMEs motivated the `"continuation"` fitting strategy with "the Delta
pathology at high `fusionreg`". That pathology was characterized when prod ran
`maxiter: 50`. At `maxiter: 200` it largely disappears **under the independent
fitter**: `shift_Delta` at `fusionreg=6.4e-4` goes 0.0778 → 0.4047, and the two
drops seen at `maxiter=50` (−0.111 at 1.6e-4; −0.089 at 3.2e-4 for BA2) both turn
positive. At a strong lasso the optimizer had simply not converged.

The README now records this **without retiring `"continuation"`** — that strategy
was never re-tested at `maxiter: 200`, so its marginal value today is unmeasured.

### Production runs

| | host | wall-clock | pickle | workers |
|---|---|---|---|---|
| spike | orca05 | 3643 s (61 min) | 1.58 GB, 18 rows | 6 × ~7 GB RSS |
| simulation | orca05 | 7519 s (125 min) | 535 MB, 54 rows | 6 × **~42 GB RSS** |

### Style/tests

`pytest tests/` **85 passed** · `black --check .` clean (32 files) ·
`ruff check multidms tests experiments/simulation experiments/scv2-spike` clean.
Note `pixi run lint` does not reach `experiments/` (ruff `extend-exclude`), so
those paths were linted explicitly.

## Deviations from spec

1. **AC4's `touch` sub-check replaced with content edits.** Snakemake 9.21
   content-hashes; a bare `touch` is inert and the check could never fail.
2. **Cosmetics passed as a config path via `params:`, not JSON-encoded values.**
   `json.dumps(...get(k,{}))` yields `"{}"`, which is not `None`, so a guard
   would never fire — the same silent-default shape this PR removes.
3. **Tests live in `tests/`, not `experiments/*/tests/`.** `testpaths =
   ["tests","multidms"]`, so the latter would never run in CI.
4. **Simulation's `cross_validation.ipynb` got no `downstream_config_path`.**
   After the AC3 deletion it reads no downstream key, and adding it would wire
   the downstream file into a fit-tier rule.
5. **AC4's simulation half asserts rule re-execution, not content change** — sim's
   `evaluate` uses `lasso_choice` only in plot queries.
6. **`n_processes` pinned to 6 in both pipelines** (was `null`). The auto-rule
   picks `min(cpu_count // 2, n_models)` from **core count alone, ignoring
   memory**. On a 36 GB laptop that chose 7 workers and kernel-panicked the host
   mid-run, losing a complete production fit. Simulation's measured per-worker
   footprint is ~42 GB — a single worker exceeds that machine's total RAM.
7. **`maxiter` split 200 outer / 10 inner** (was 100/100 sim, 50/50 spike). The
   inner `ge_kwargs`/`cal_kwargs` values had always mirrored the outer value and
   were never tuned independently. This supersedes an earlier spike prod run on
   this branch fit at `maxiter=50`.
8. **Corrected a factual error in both READMEs' tier docs.** They claimed
   Snakemake reruns on mtime "not content," which is backwards for 9.21 and
   contradicted the AC4 finding above.
9. **Simulation's README advertised `maxiter=100`** in its Configuration section,
   contradicting the shipped config. Corrected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
