### PR TITLE
Replace psf/black action with direct black --check (GHSA-v53h-f6m7-xcgm)

### DIFF
--- a/.github/workflows/build_test_package.yml
+++ b/.github/workflows/build_test_package.yml
@@ -46,13 +46,10 @@ jobs:
             pip install --upgrade pip
             pip install -e ".[dev]"
       
+      # Uses the black pinned by the [dev] extra (black~=23.3.0), which matches
+      # the version shipped with the vs code extension.
       - name: Black Format Check
-        uses: psf/black@24.10.0
-        with:
-          options: "--check"
-          src: "."
-          jupyter: false
-          version: "~= 23.3.0" # this is the version that ships with the vs code extension, currently
+        run: black --check .
 
       # On pull requests, run only the fast tests + doctests (the default
       # marker filter from pyproject deselects the JAX model-fitting suites,

--- a/.github/workflows/build_test_package.yml
+++ b/.github/workflows/build_test_package.yml
@@ -47,7 +47,7 @@ jobs:
             pip install -e ".[dev]"
       
       - name: Black Format Check
-        uses: psf/black@26.3.0
+        uses: psf/black@24.10.0
         with:
           options: "--check"
           src: "."

--- a/.github/workflows/build_test_package.yml
+++ b/.github/workflows/build_test_package.yml
@@ -47,7 +47,7 @@ jobs:
             pip install -e ".[dev]"
       
       - name: Black Format Check
-        uses: psf/black@24.10.0
+        uses: psf/black@26.3.0
         with:
           options: "--check"
           src: "."


### PR DESCRIPTION
Resolves the high-severity Dependabot alert by removing the vulnerable action entirely.

## Why not just bump the pin

The first attempt (bumping `psf/black@24.10.0` → `@26.3.0`) failed all four CI jobs:

```
File ".../psf/black/26.3.0/action/main.py", line 102
    def find_black_version_in_array(array: object) -> str | None:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

`str | None` is PEP 604 syntax requiring Python 3.10+. The action runs its `main.py` under the matrix Python, so it crashes on the 3.9 legs before black ever executes. Line 102 is byte-identical in `26.3.0`, `26.3.1`, `26.5.0`, and `26.5.1`, with no `from __future__ import annotations` — so **no patched version is compatible with our 3.9 matrix leg**.

(The 3.11 jobs passed the Black step; they showed red only because matrix fail-fast cancelled them.)

## What this does instead

Drops the action and calls black directly. The `[dev]` extra already pins `black~=23.3.0` (`pyproject.toml:68`) — the same constraint the action's `version:` input carried — and is installed one step earlier, so formatting behavior is unchanged.

Verified locally: `black --check` over all 32 tracked `.py` files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)